### PR TITLE
chore: update repository URLs to Forge-Space/core

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,12 +91,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/LucasSantana-Dev/forge-patterns.git"
+    "url": "https://github.com/Forge-Space/core.git"
   },
   "bugs": {
-    "url": "https://github.com/LucasSantana-Dev/forge-patterns/issues"
+    "url": "https://github.com/Forge-Space/core/issues"
   },
-  "homepage": "https://github.com/LucasSantana-Dev/forge-patterns#readme",
+  "homepage": "https://github.com/Forge-Space/core#readme",
   "engines": {
     "node": ">=22.0.0",
     "npm": ">=9.0.0"


### PR DESCRIPTION
Updates `repository`, `bugs`, and `homepage` URLs in `package.json` to reflect the new `Forge-Space/core` location after org transfer.