### PR TITLE
chore(ci): migrate publish workflow to npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    name: Publish @uiforge/forge-patterns
+    name: Publish @forgespace/core
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -34,6 +34,4 @@ jobs:
         run: npm test
 
       - name: Publish to npm
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance


### PR DESCRIPTION
Migrates from `NPM_TOKEN` secret to npm Trusted Publishing via OIDC.\n\n## Changes\n- Removed `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` — no long-lived token needed\n- Added `--provenance` flag — provenance attestations auto-generated\n- Fixed job name: `@uiforge/forge-patterns` → `@forgespace/core`\n- `id-token: write` permission already present\n\n## Required manual step (npmjs.com)\nBefore the next tag publish, configure the Trusted Publisher on npmjs.com:\n1. Go to https://www.npmjs.com/package/@forgespace/core → Settings → Trusted Publishers\n2. Click **GitHub Actions** → **Add**\n3. Fill in:\n   - **Repository owner**: `Forge-Space`\n   - **Repository name**: `core`\n   - **Workflow filename**: `publish.yml`\n4. Save\n\nAfter that, pushing a `v*` tag will publish without any token.