### PR TITLE
docs: Add standardized Forge Space wordmark header to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# Forge-Space Core
-
-> **Shared standards, patterns, and MCP context server for the Forge Space ecosystem.**
+<div align="center">
+  <a href="https://forgespace.co">
+    <img src="https://brand.forgespace.co/logos/wordmark.svg" alt="Forge Space" height="48">
+  </a>
+  <h1>Forge-Space Core</h1>
+  <p>Shared standards, patterns, and MCP context server for the Forge Space ecosystem.</p>
+</div>
 
 Part of [Forge Space](https://github.com/Forge-Space) — the open full-stack AI workspace. This repo provides the foundation that all other Forge Space projects build on: code quality standards, security framework, CI/CD workflows, and a local MCP context server for IDE integration.
 


### PR DESCRIPTION
## Summary
- Adds Forge Space anvil wordmark logo header to README
- Part of cross-repo brand standardization (brand-guide as single source of truth)
- Logo served from brand.forgespace.co/logos/wordmark.svg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Documentation**
  * Updated README header with improved visual presentation, including a centered logo, title, and project description for better first-time user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->