### PR TITLE
fix(ci): Add NODE_AUTH_TOKEN to npm publish step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,3 +35,5 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds missing `NODE_AUTH_TOKEN` env var to the publish workflow's npm publish step
- Root cause of 3 consecutive v1.3.2 publish failures (E404 on `@forgespace/core`)
- `setup-node` creates `.npmrc` referencing `$NODE_AUTH_TOKEN` but the env var was never set

## Test plan
- [x] Matches working pattern in siza-gen's publish.yml
- [ ] Merge → delete v1.3.2 tag → re-push tag → verify publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)