### PR TITLE
chore: Release v1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.3.3] - 2026-03-01
+
+### Fixed
+- **CI**: Add missing `NODE_AUTH_TOKEN` to npm publish workflow (fixes E404 on scoped package publish)
+
+---
+
 ## [1.3.2] - 2026-02-28
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@forgespace/core",
-  "version": "1.3.1",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@forgespace/core",
-      "version": "1.3.1",
+      "version": "1.3.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgespace/core",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Shared configuration, workflows, and architectural patterns for the Forgespace ecosystem",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Version bump to 1.3.3
- Fix npm publish pipeline (NODE_AUTH_TOKEN was missing)
- After merge: push v1.3.3 tag to trigger publish workflow

## Test plan
- [x] CI passes
- [ ] After merge, push tag: `git tag v1.3.3 && git push origin v1.3.3`
- [ ] Verify npm publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)