### PR TITLE
feat: Add fast-check property tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-import-resolver-typescript": "^3.10.1",
         "eslint-plugin-import": "^2.32.0",
+        "fast-check": "^4.5.3",
         "globals": "^17.3.0",
         "husky": "^8.0.3",
         "jest": "^29.7.0",
@@ -5123,6 +5124,46 @@
       "peerDependencies": {
         "express": ">= 4.11"
       }
+    },
+    "node_modules/fast-check": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.5.3.tgz",
+      "integrity": "sha512-IE9csY7lnhxBnA8g/WI5eg/hygA6MGWJMSNfFRrBlXUciADEhS1EDB0SIsMSvzubzIlOBbVITSsypCsW717poA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/fast-check/node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^3.10.1",
     "eslint-plugin-import": "^2.32.0",
+    "fast-check": "^4.5.3",
     "globals": "^17.3.0",
     "husky": "^8.0.3",
     "jest": "^29.7.0",

--- a/patterns/idp/__tests__/policy-engine.property.test.ts
+++ b/patterns/idp/__tests__/policy-engine.property.test.ts
@@ -1,0 +1,192 @@
+import fc from 'fast-check';
+import { evaluateCondition, resolveFieldPath } from '../policy-engine/builtin-functions.js';
+
+describe('evaluateCondition — property tests', () => {
+  describe('eq/ne are complementary', () => {
+    it('eq and ne always produce opposite results for same inputs', () => {
+      fc.assert(
+        fc.property(fc.anything(), fc.anything(), (a, b) => {
+          const eq = evaluateCondition('eq', a, b);
+          const ne = evaluateCondition('ne', a, b);
+          expect(eq).toBe(!ne);
+        })
+      );
+    });
+  });
+
+  describe('numeric comparisons are consistent', () => {
+    it('gt and lte are complementary for valid numbers', () => {
+      fc.assert(
+        fc.property(fc.integer(), fc.integer(), (a, b) => {
+          const gt = evaluateCondition('gt', a, b);
+          const lte = evaluateCondition('lte', a, b);
+          expect(gt).toBe(!lte);
+        })
+      );
+    });
+
+    it('lt and gte are complementary for valid numbers', () => {
+      fc.assert(
+        fc.property(fc.integer(), fc.integer(), (a, b) => {
+          const lt = evaluateCondition('lt', a, b);
+          const gte = evaluateCondition('gte', a, b);
+          expect(lt).toBe(!gte);
+        })
+      );
+    });
+
+    it('gt is transitive: a > b && b > c implies a > c', () => {
+      fc.assert(
+        fc.property(fc.integer(), fc.integer(), fc.integer(), (a, b, c) => {
+          const ab = evaluateCondition('gt', a, b);
+          const bc = evaluateCondition('gt', b, c);
+          if (ab && bc) {
+            expect(evaluateCondition('gt', a, c)).toBe(true);
+          }
+        })
+      );
+    });
+
+    it('eq is reflexive: a eq a is always true for numbers', () => {
+      fc.assert(
+        fc.property(fc.integer(), (a) => {
+          expect(evaluateCondition('eq', a, a)).toBe(true);
+        })
+      );
+    });
+
+    it('numeric string coercion: "5" gt 3 should be true', () => {
+      fc.assert(
+        fc.property(fc.integer({ min: -1000, max: 1000 }), (n) => {
+          const strN = String(n);
+          expect(evaluateCondition('eq', n, n)).toBe(true);
+          expect(evaluateCondition('gt', strN, n - 1)).toBe(true);
+          expect(evaluateCondition('lt', strN, n + 1)).toBe(true);
+        })
+      );
+    });
+  });
+
+  describe('non-numeric inputs return false for comparisons', () => {
+    it('gt/gte/lt/lte return false for non-numeric values', () => {
+      fc.assert(
+        fc.property(
+          fc.oneof(fc.boolean(), fc.constant(null), fc.constant(undefined)),
+          fc.integer(),
+          (nonNum, num) => {
+            expect(evaluateCondition('gt', nonNum, num)).toBe(false);
+            expect(evaluateCondition('gte', nonNum, num)).toBe(false);
+            expect(evaluateCondition('lt', nonNum, num)).toBe(false);
+            expect(evaluateCondition('lte', nonNum, num)).toBe(false);
+          }
+        )
+      );
+    });
+  });
+
+  describe('contains', () => {
+    it('string always contains itself', () => {
+      fc.assert(
+        fc.property(fc.string(), (s) => {
+          expect(evaluateCondition('contains', s, s)).toBe(true);
+        })
+      );
+    });
+
+    it('string always contains empty string', () => {
+      fc.assert(
+        fc.property(fc.string(), (s) => {
+          expect(evaluateCondition('contains', s, '')).toBe(true);
+        })
+      );
+    });
+
+    it('array contains its own elements', () => {
+      fc.assert(
+        fc.property(
+          fc.array(fc.integer(), { minLength: 1 }),
+          (arr) => {
+            const idx = Math.floor(Math.random() * arr.length);
+            expect(evaluateCondition('contains', arr, arr[idx])).toBe(true);
+          }
+        )
+      );
+    });
+  });
+
+  describe('matches', () => {
+    it('returns false for non-string inputs', () => {
+      fc.assert(
+        fc.property(fc.integer(), fc.string(), (num, pattern) => {
+          expect(evaluateCondition('matches', num, pattern)).toBe(false);
+        })
+      );
+    });
+
+    it('rejects patterns longer than 200 chars', () => {
+      fc.assert(
+        fc.property(
+          fc.string(),
+          fc.string({ minLength: 201, maxLength: 300 }),
+          (input, longPattern) => {
+            expect(evaluateCondition('matches', input, longPattern)).toBe(false);
+          }
+        )
+      );
+    });
+  });
+});
+
+describe('resolveFieldPath — property tests', () => {
+  it('resolves single-level paths', () => {
+    fc.assert(
+      fc.property(
+        fc.string().filter(s => s.length > 0 && !s.includes('.') && !['__proto__', 'constructor', 'prototype'].includes(s)),
+        fc.anything(),
+        (key, value) => {
+          const obj: Record<string, unknown> = { [key]: value };
+          expect(resolveFieldPath(obj, key)).toBe(value);
+        }
+      )
+    );
+  });
+
+  it('returns undefined for missing paths', () => {
+    fc.assert(
+      fc.property(fc.string({ minLength: 1 }).filter(s => s !== 'existing'), (key) => {
+        expect(resolveFieldPath({ existing: 1 }, key)).toBeUndefined();
+      })
+    );
+  });
+
+  it('blocks prototype pollution paths', () => {
+    const dangerousPaths = ['__proto__', 'constructor', 'prototype'];
+    for (const path of dangerousPaths) {
+      expect(resolveFieldPath({ [path]: 'evil' }, path)).toBeUndefined();
+    }
+    expect(resolveFieldPath({ a: { __proto__: 'evil' } }, 'a.__proto__')).toBeUndefined();
+  });
+
+  it('rejects paths deeper than MAX_DEPTH (10)', () => {
+    const deepPath = Array.from({ length: 11 }, (_, i) => `k${i}`).join('.');
+    let obj: Record<string, unknown> = { value: true };
+    for (let i = 10; i >= 0; i--) {
+      obj = { [`k${i}`]: obj };
+    }
+    expect(resolveFieldPath(obj, deepPath)).toBeUndefined();
+  });
+
+  it('resolves nested paths correctly', () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1 }).filter(s => !s.includes('.') && !['__proto__', 'constructor', 'prototype'].includes(s)),
+        fc.string({ minLength: 1 }).filter(s => !s.includes('.') && !['__proto__', 'constructor', 'prototype'].includes(s)),
+        fc.anything(),
+        (k1, k2, value) => {
+          const obj = { [k1]: { [k2]: value } };
+          expect(resolveFieldPath(obj, `${k1}.${k2}`)).toBe(value);
+        }
+      )
+    );
+  });
+});

--- a/patterns/idp/__tests__/post-gen-scorer.property.test.ts
+++ b/patterns/idp/__tests__/post-gen-scorer.property.test.ts
@@ -1,0 +1,110 @@
+import fc from 'fast-check';
+import { scoreGeneratedCode } from '../scorecards/post-gen-scorer.js';
+
+describe('scoreGeneratedCode — property tests', () => {
+  it('score is always between 0 and 100', () => {
+    fc.assert(
+      fc.property(fc.string(), (code) => {
+        const result = scoreGeneratedCode(code);
+        expect(result.score).toBeGreaterThanOrEqual(0);
+        expect(result.score).toBeLessThanOrEqual(100);
+      })
+    );
+  });
+
+  it('grade is consistent with score', () => {
+    fc.assert(
+      fc.property(fc.string(), (code) => {
+        const { score, grade } = scoreGeneratedCode(code);
+        if (score >= 90) expect(grade).toBe('A');
+        else if (score >= 75) expect(grade).toBe('B');
+        else if (score >= 60) expect(grade).toBe('C');
+        else if (score >= 40) expect(grade).toBe('D');
+        else expect(grade).toBe('F');
+      })
+    );
+  });
+
+  it('passed respects minScore threshold', () => {
+    fc.assert(
+      fc.property(
+        fc.string(),
+        fc.integer({ min: 0, max: 100 }),
+        (code, minScore) => {
+          const result = scoreGeneratedCode(code, { minScore });
+          expect(result.passed).toBe(result.score >= minScore);
+        }
+      )
+    );
+  });
+
+  it('all checks have positive weight', () => {
+    fc.assert(
+      fc.property(fc.string(), (code) => {
+        const result = scoreGeneratedCode(code);
+        for (const check of result.checks) {
+          expect(check.weight).toBeGreaterThan(0);
+        }
+      })
+    );
+  });
+
+  it('timestamp is valid ISO format', () => {
+    fc.assert(
+      fc.property(fc.string(), (code) => {
+        const result = scoreGeneratedCode(code);
+        expect(new Date(result.timestamp).toISOString()).toBe(result.timestamp);
+      })
+    );
+  });
+
+  it('clean code scores higher than code with anti-patterns', () => {
+    const clean = 'export function hello(): string { return "hi"; }';
+    const dirty = 'export function hello(): string { console.log("debug"); // TODO fix\nreturn "hi"; }';
+
+    const cleanScore = scoreGeneratedCode(clean);
+    const dirtyScore = scoreGeneratedCode(dirty);
+
+    expect(cleanScore.score).toBeGreaterThanOrEqual(dirtyScore.score);
+  });
+
+  it('react framework adds additional checks', () => {
+    fc.assert(
+      fc.property(fc.string(), (code) => {
+        const withReact = scoreGeneratedCode(code, { framework: 'react' });
+        const withoutFramework = scoreGeneratedCode(code);
+
+        expect(withReact.checks.length).toBeGreaterThanOrEqual(
+          withoutFramework.checks.length
+        );
+      })
+    );
+  });
+
+  it('typescript: false removes type checks', () => {
+    fc.assert(
+      fc.property(fc.string(), (code) => {
+        const withTs = scoreGeneratedCode(code, { typescript: true });
+        const withoutTs = scoreGeneratedCode(code, { typescript: false });
+
+        expect(withTs.checks.length).toBeGreaterThanOrEqual(
+          withoutTs.checks.length
+        );
+      })
+    );
+  });
+
+  it('code with exports scores higher on has-export check', () => {
+    const withExport = 'export const foo = 42;';
+    const withoutExport = 'const foo = 42;';
+
+    const exportResult = scoreGeneratedCode(withExport);
+    const noExportResult = scoreGeneratedCode(withoutExport);
+
+    const exportCheck = exportResult.checks.find(c => c.name === 'has-export');
+    const noExportCheck = noExportResult.checks.find(c => c.name === 'has-export');
+
+    expect(exportCheck?.passed).toBe(true);
+    expect(noExportCheck?.passed).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Install fast-check for property-based testing
- 17 property tests for policy engine (evaluateCondition, resolveFieldPath)
- 9 property tests for post-gen scorer (score bounds, grade, thresholds)
- Verifies: operator complementarity, transitivity, prototype pollution blocking, score consistency
- Total: 379 tests across 17 suites (was 353)

## Test plan
- [x] `npm test` passes (379/379)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)