### PR TITLE
chore: Upgrade Husky 8→9 and MCP SDK to ^1.27.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.0.0",
+        "@modelcontextprotocol/sdk": "^1.27.1",
         "chalk": "^5.3.0",
         "commander": "^11.0.0",
         "fs-extra": "^11.1.1",
@@ -38,7 +38,7 @@
         "eslint-plugin-import": "^2.32.0",
         "fast-check": "^4.5.3",
         "globals": "^17.3.0",
-        "husky": "^8.0.3",
+        "husky": "^9.1.7",
         "jest": "^29.7.0",
         "knip": "^5.85.0",
         "lint-staged": "^16.2.7",
@@ -5922,16 +5922,16 @@
       }
     },
     "node_modules/husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "husky": "lib/bin.js"
+        "husky": "bin.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test:shared-constants": "node test/shared-constants-validation.js",
     "test:all": "npm run test:validation && npm run test:coverage",
     "knip": "knip",
-    "prepare": "npm run build && husky install",
+    "prepare": "npm run build && husky",
     "pre-commit": "npm run lint && npm run format && npm run test:validation && .husky/pre-commit-backup-check",
     "prepack": "npm run build",
     "publish:npm": "npm publish --access public",
@@ -64,7 +64,7 @@
     "forge-features": "dist/patterns/idp/feature-toggles/cli.js"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "chalk": "^5.3.0",
     "commander": "^11.0.0",
     "fs-extra": "^11.1.1",
@@ -87,7 +87,7 @@
     "eslint-plugin-import": "^2.32.0",
     "fast-check": "^4.5.3",
     "globals": "^17.3.0",
-    "husky": "^8.0.3",
+    "husky": "^9.1.7",
     "jest": "^29.7.0",
     "knip": "^5.85.0",
     "lint-staged": "^16.2.7",


### PR DESCRIPTION
## Summary
- Upgrade Husky from ^8.0.3 to ^9.1.7 (v9 format)
- Upgrade @modelcontextprotocol/sdk from ^1.0.0 to ^1.27.1
- Remove legacy `.husky/_/` directory
- Update prepare script for Husky 9

## Test plan
- [x] 379 tests passing locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)