### PR TITLE
chore: Add catalog-info.yaml for IDP service catalog

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,15 @@
+apiVersion: backstage.io/v1alpha1
+kind: Library
+metadata:
+  name: forge-patterns
+  description: Shared patterns, scorecards, policy engine, and CLI tools for Forge Space ecosystem
+  tags:
+    - typescript
+    - npm
+    - governance
+    - patterns
+spec:
+  owner: forge-space
+  system: siza
+  lifecycle: production
+  dependsOn: []


### PR DESCRIPTION
## Summary
- Add Backstage-compatible catalog-info.yaml to enable IDP service catalog discovery
- Defines forge-patterns as a Library component with metadata and tags
- Part of dogfooding our own IDP infrastructure across all 9 Forge Space repos

## Test plan
- [x] File created with valid YAML syntax
- [ ] Verify catalog-info.yaml appears in service catalog after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)