### PR TITLE
ci: Use org composite action for Node.js setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-      - run: npm ci
+      - uses: Forge-Space/.github/.github/actions/setup-node@main
       - run: npm run lint:check
       - run: npm run format:check
 
@@ -28,48 +23,28 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-      - run: npm ci
+      - uses: Forge-Space/.github/.github/actions/setup-node@main
       - run: npm test
 
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-      - run: npm ci
+      - uses: Forge-Space/.github/.github/actions/setup-node@main
       - run: npm run build
 
   validation:
     name: Pattern Validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-      - run: npm ci
+      - uses: Forge-Space/.github/.github/actions/setup-node@main
       - run: npm run test:validation
 
   security:
     name: Security Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-      - run: npm ci
+      - uses: Forge-Space/.github/.github/actions/setup-node@main
       - name: Run npm audit
         run: npm audit --audit-level=high --omit=dev
         continue-on-error: true


### PR DESCRIPTION
## Summary
- Replace repeated `checkout` + `setup-node` + `npm ci` steps with org-wide composite action
- Reduces boilerplate from 30 lines to 5 uses
- Maintains all job names, triggers, concurrency, and test steps

## Test plan
- [x] CI workflow uses `Forge-Space/.github/.github/actions/setup-node@main`
- [ ] Verify all 5 jobs run successfully (lint, test, build, validation, security)
- [ ] Confirm dependency caching works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)