### PR TITLE
fix: correct package entry point and add IDP barrel re-exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.10.1] - 2026-03-08
+
+### Fixed
+- **Package entry point**: Fixed `main`/`types` pointing to `dist/index.js` instead of `dist/src/index.js` (tsc `rootDir: "./"` outputs to `dist/src/`)
+- **Barrel re-exports**: `src/index.ts` now re-exports all IDP patterns (migration, scorecards, policy-engine, feature-toggles)
+- **`exports` map**: Added package.json `exports` field for proper ESM/CJS resolution
+- Consumers can now `import { assessProject } from '@forgespace/core'` without bundler workarounds
+
 ## [1.10.0] - 2026-03-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,9 +1,15 @@
 {
   "name": "@forgespace/core",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Shared configuration, workflows, and architectural patterns for the Forgespace ecosystem",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
+    }
+  },
   "files": [
     "dist/",
     "patterns/",

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,5 +101,8 @@ export class ForgePatterns {
   }
 }
 
+// IDP Patterns re-exports
+export * from '../patterns/idp/index.js';
+
 // Export default instance
 export default ForgePatterns.getInstance();


### PR DESCRIPTION
## Summary
- Fixed `main`/`types` pointing to non-existent `dist/index.js` — actual tsc output is `dist/src/index.js`
- Added `exports` map for proper ESM resolution
- Re-exported all IDP patterns (migration, scorecards, policy-engine, feature-toggles) from `src/index.ts`
- Consumers can now `import { assessProject } from '@forgespace/core'` without bundler workarounds

## Test plan
- [x] `npm run build` passes
- [x] `npm run test:validation` passes (44/44)
- [x] `node -e "import('@forgespace/core').then(m => console.log(Object.keys(m)))"` resolves correctly
- [x] Verified `assessProject` and `detectStrategy` are exported

🤖 Generated with [Claude Code](https://claude.com/claude-code)