### PR TITLE
fix: prevent init CLI side effects when importing @forgespace/core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+### Fixed
+- **IDP init import side effects** — Package root imports no longer trigger `forge-init` writes.
+  `initProject` now lives in side-effect-free `patterns/idp/init/project.ts`, CLI execution in
+  `patterns/idp/init/cli.ts` is entrypoint-guarded, and IDP barrel exports avoid CLI module
+  loading at import time.
+
 ### Changed
 - **TypeScript ESLint alignment** — Synchronized `@typescript-eslint/eslint-plugin`,
   `@typescript-eslint/parser`, and `typescript-eslint` to `8.57.0` to keep peer

--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ CLI tools for project governance, shipped as part of `@forgespace/core`:
 | **Feature Toggles** | `npx forge-features` | Manage file-based feature toggles |
 | **Audit** | `npx forge-audit` | Assess legacy codebase migration readiness |
 
+### Runtime Import Safety
+
+Importing `@forgespace/core` is side-effect free. Governance scaffolding runs only when
+`forge-init` is executed as a CLI command (`npx forge-init` or `forge-init` binary), not when the
+package is imported in application runtime code.
+
 ### Quick Start
 
 ```bash

--- a/patterns/idp/index.ts
+++ b/patterns/idp/index.ts
@@ -1,5 +1,5 @@
 export * from './feature-toggles/index.js';
 export * from './policy-engine/index.js';
 export * from './scorecards/index.js';
-export { initProject } from './init/cli.js';
+export { initProject } from './init/project.js';
 export * from './migration/index.js';

--- a/patterns/idp/init/cli.ts
+++ b/patterns/idp/init/cli.ts
@@ -1,127 +1,9 @@
 #!/usr/bin/env node
 
-import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
-import { resolve, join } from 'node:path';
-import { type TemplateName, TEMPLATE_NAMES, getTemplate, isValidTemplate } from './templates.js';
-
-const SCORECARD_CONFIG = {
-  threshold: 60,
-  collectors: ['security', 'quality', 'performance', 'compliance'],
-  output: 'summary'
-};
-
-const FEATURES_SEED = {
-  toggles: [],
-  version: '1.0.0'
-};
-
-function scorecardWorkflow(): string {
-  return `name: Scorecard
-
-on:
-  pull_request:
-    branches: [main]
-
-permissions:
-  contents: read
-  pull-requests: write
-
-jobs:
-  scorecard:
-    name: Project Scorecard
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-
-      - run: npm ci
-
-      - name: Run scorecard
-        id: scorecard
-        continue-on-error: true
-        run: |
-          OUTPUT=$(npx forge-scorecard --project-dir . --threshold 60 --output summary 2>&1) || true
-          echo "result<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$OUTPUT" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
-          npx forge-scorecard --project-dir . --threshold 60 --output json > /dev/null 2>&1
-          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
-
-      - name: Comment on PR
-        if: always()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const body = \`## Project Scorecard\\n\\n\\\`\\\`\\\`\\n\${process.env.SCORECARD_RESULT}\\n\\\`\\\`\\\`\`;
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find(c =>
-              c.body?.includes('## Project Scorecard')
-            );
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
-        env:
-          SCORECARD_RESULT: \${{ steps.scorecard.outputs.result }}
-`;
-}
-
-function policyWorkflow(): string {
-  return `name: Policy Check
-
-on:
-  pull_request:
-    branches: [main]
-
-permissions:
-  contents: read
-
-jobs:
-  policy-check:
-    name: Policy Evaluation
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-
-      - run: npm ci
-
-      - name: Run policy check
-        continue-on-error: true
-        run: |
-          npx forge-policy \\
-            --policy-dir .forge/policies \\
-            --fail-on-block
-`;
-}
-
-interface InitResult {
-  created: string[];
-  skipped: string[];
-}
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { type TemplateName, TEMPLATE_NAMES, isValidTemplate } from './templates.js';
+import { initProject } from './project.js';
 
 function printUsage(): void {
   console.log(`
@@ -165,116 +47,6 @@ function parseArgs(args: string[]) {
     }
   }
   return opts;
-}
-
-function loadBundledPolicy(name: string): string {
-  const policyPath = resolve(__dirname, '..', 'policies', `${name}.policy.json`);
-  if (existsSync(policyPath)) {
-    return readFileSync(policyPath, 'utf-8');
-  }
-  return JSON.stringify(
-    {
-      id: `forge-${name}`,
-      name: `Forge ${name.charAt(0).toUpperCase() + name.slice(1)} Policy`,
-      version: '1.0.0',
-      description: `Default ${name} policy`,
-      rules: []
-    },
-    null,
-    2
-  );
-}
-
-function writeIfNeeded(
-  filePath: string,
-  content: string,
-  force: boolean,
-  dryRun: boolean,
-  result: InitResult
-): void {
-  if (existsSync(filePath) && !force) {
-    result.skipped.push(filePath);
-    return;
-  }
-  if (dryRun) {
-    result.created.push(filePath);
-    return;
-  }
-  const dir = filePath.substring(0, filePath.lastIndexOf('/'));
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(filePath, content, 'utf-8');
-  result.created.push(filePath);
-}
-
-export function initProject(
-  targetDir: string,
-  options: {
-    force?: boolean;
-    dryRun?: boolean;
-    template?: TemplateName;
-  } = {}
-): InitResult {
-  const force = options.force ?? false;
-  const dryRun = options.dryRun ?? false;
-  const result: InitResult = { created: [], skipped: [] };
-
-  const forgeDir = join(targetDir, '.forge');
-  const policiesDir = join(forgeDir, 'policies');
-  const workflowsDir = join(targetDir, '.github', 'workflows');
-
-  for (const name of ['security', 'quality', 'compliance']) {
-    const content = loadBundledPolicy(name);
-    writeIfNeeded(join(policiesDir, `${name}.policy.json`), content, force, dryRun, result);
-  }
-
-  const scorecardConfig = options.template
-    ? {
-        ...SCORECARD_CONFIG,
-        weights: getTemplate(options.template).scorecardWeights
-      }
-    : SCORECARD_CONFIG;
-
-  writeIfNeeded(
-    join(forgeDir, 'scorecard.json'),
-    JSON.stringify(scorecardConfig, null, 2) + '\n',
-    force,
-    dryRun,
-    result
-  );
-
-  writeIfNeeded(
-    join(forgeDir, 'features.json'),
-    JSON.stringify(FEATURES_SEED, null, 2) + '\n',
-    force,
-    dryRun,
-    result
-  );
-
-  writeIfNeeded(join(workflowsDir, 'scorecard.yml'), scorecardWorkflow(), force, dryRun, result);
-
-  writeIfNeeded(join(workflowsDir, 'policy-check.yml'), policyWorkflow(), force, dryRun, result);
-
-  if (options.template) {
-    const tmpl = getTemplate(options.template);
-    for (const [name, rules] of Object.entries(tmpl.policies)) {
-      const policy = {
-        id: `forge-${name}`,
-        name: `Forge ${name.charAt(0).toUpperCase() + name.slice(1)} Policy`,
-        version: '1.0.0',
-        description: `Framework-specific ${name} governance rules`,
-        rules
-      };
-      writeIfNeeded(
-        join(policiesDir, `${name}.policy.json`),
-        JSON.stringify(policy, null, 2) + '\n',
-        force,
-        dryRun,
-        result
-      );
-    }
-  }
-
-  return result;
 }
 
 function main(): void {
@@ -343,4 +115,9 @@ function main(): void {
   }
 }
 
-main();
+if (typeof require !== 'undefined' && typeof module !== 'undefined' && require.main === module) {
+  main();
+}
+
+export { initProject } from './project.js';
+export type { InitResult } from './project.js';

--- a/patterns/idp/init/project.ts
+++ b/patterns/idp/init/project.ts
@@ -1,0 +1,232 @@
+import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import { type TemplateName, getTemplate } from './templates.js';
+
+const SCORECARD_CONFIG = {
+  threshold: 60,
+  collectors: ['security', 'quality', 'performance', 'compliance'],
+  output: 'summary'
+};
+
+const FEATURES_SEED = {
+  toggles: [],
+  version: '1.0.0'
+};
+
+function scorecardWorkflow(): string {
+  return `name: Scorecard
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  scorecard:
+    name: Project Scorecard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Run scorecard
+        id: scorecard
+        continue-on-error: true
+        run: |
+          OUTPUT=$(npx forge-scorecard --project-dir . --threshold 60 --output summary 2>&1) || true
+          echo "result<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$OUTPUT" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          npx forge-scorecard --project-dir . --threshold 60 --output json > /dev/null 2>&1
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on PR
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = \`## Project Scorecard\\n\\n\\\`\\\`\\\`\\n\${process.env.SCORECARD_RESULT}\\n\\\`\\\`\\\`\`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c =>
+              c.body?.includes('## Project Scorecard')
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+        env:
+          SCORECARD_RESULT: \${{ steps.scorecard.outputs.result }}
+`;
+}
+
+function policyWorkflow(): string {
+  return `name: Policy Check
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  policy-check:
+    name: Policy Evaluation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Run policy check
+        continue-on-error: true
+        run: |
+          npx forge-policy \\
+            --policy-dir .forge/policies \\
+            --fail-on-block
+`;
+}
+
+export interface InitResult {
+  created: string[];
+  skipped: string[];
+}
+
+function loadBundledPolicy(name: string): string {
+  const policyPath = resolve(__dirname, '..', 'policies', `${name}.policy.json`);
+  if (existsSync(policyPath)) {
+    return readFileSync(policyPath, 'utf-8');
+  }
+  return JSON.stringify(
+    {
+      id: `forge-${name}`,
+      name: `Forge ${name.charAt(0).toUpperCase() + name.slice(1)} Policy`,
+      version: '1.0.0',
+      description: `Default ${name} policy`,
+      rules: []
+    },
+    null,
+    2
+  );
+}
+
+function writeIfNeeded(
+  filePath: string,
+  content: string,
+  force: boolean,
+  dryRun: boolean,
+  result: InitResult
+): void {
+  if (existsSync(filePath) && !force) {
+    result.skipped.push(filePath);
+    return;
+  }
+  if (dryRun) {
+    result.created.push(filePath);
+    return;
+  }
+  const dir = filePath.substring(0, filePath.lastIndexOf('/'));
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(filePath, content, 'utf-8');
+  result.created.push(filePath);
+}
+
+export function initProject(
+  targetDir: string,
+  options: {
+    force?: boolean;
+    dryRun?: boolean;
+    template?: TemplateName;
+  } = {}
+): InitResult {
+  const force = options.force ?? false;
+  const dryRun = options.dryRun ?? false;
+  const result: InitResult = { created: [], skipped: [] };
+
+  const forgeDir = join(targetDir, '.forge');
+  const policiesDir = join(forgeDir, 'policies');
+  const workflowsDir = join(targetDir, '.github', 'workflows');
+
+  for (const name of ['security', 'quality', 'compliance']) {
+    const content = loadBundledPolicy(name);
+    writeIfNeeded(join(policiesDir, `${name}.policy.json`), content, force, dryRun, result);
+  }
+
+  const scorecardConfig = options.template
+    ? {
+        ...SCORECARD_CONFIG,
+        weights: getTemplate(options.template).scorecardWeights
+      }
+    : SCORECARD_CONFIG;
+
+  writeIfNeeded(
+    join(forgeDir, 'scorecard.json'),
+    JSON.stringify(scorecardConfig, null, 2) + '\n',
+    force,
+    dryRun,
+    result
+  );
+
+  writeIfNeeded(
+    join(forgeDir, 'features.json'),
+    JSON.stringify(FEATURES_SEED, null, 2) + '\n',
+    force,
+    dryRun,
+    result
+  );
+
+  writeIfNeeded(join(workflowsDir, 'scorecard.yml'), scorecardWorkflow(), force, dryRun, result);
+
+  writeIfNeeded(join(workflowsDir, 'policy-check.yml'), policyWorkflow(), force, dryRun, result);
+
+  if (options.template) {
+    const tmpl = getTemplate(options.template);
+    for (const [name, rules] of Object.entries(tmpl.policies)) {
+      const policy = {
+        id: `forge-${name}`,
+        name: `Forge ${name.charAt(0).toUpperCase() + name.slice(1)} Policy`,
+        version: '1.0.0',
+        description: `Framework-specific ${name} governance rules`,
+        rules
+      };
+      writeIfNeeded(
+        join(policiesDir, `${name}.policy.json`),
+        JSON.stringify(policy, null, 2) + '\n',
+        force,
+        dryRun,
+        result
+      );
+    }
+  }
+
+  return result;
+}

--- a/src/import-side-effects.test.js
+++ b/src/import-side-effects.test.js
@@ -1,0 +1,25 @@
+/* global describe, it, expect, beforeEach, afterEach, jest */
+
+const fs = require('node:fs');
+
+describe('Core package import side effects', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('does not write project files when importing package root', () => {
+    const mkdirSpy = jest.spyOn(fs, 'mkdirSync');
+    const writeSpy = jest.spyOn(fs, 'writeFileSync');
+
+    jest.isolateModules(() => {
+      require('./index');
+    });
+
+    expect(mkdirSpy).not.toHaveBeenCalled();
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- move `initProject` implementation to side-effect-free `patterns/idp/init/project.ts`
- keep `patterns/idp/init/cli.ts` as CLI-only surface and guard execution to direct-entrypoint usage
- switch IDP barrel export to `./init/project.js` so runtime imports do not load CLI runtime
- add regression test to ensure importing package root does not write files
- update README and CHANGELOG with runtime import safety note

## Validation
- `npm run lint:check` (passes with existing repo warnings only)
- `npm run format:check`
- `npm test -- src/import-side-effects.test.js patterns/idp/__tests__/init-cli.test.ts`
- `npm run build`

Closes #124


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unintended side effects that occurred when importing the package root; initialization now only runs when the CLI tool is explicitly executed, not during import time.

* **Documentation**
  * Added "Runtime Import Safety" section documenting that package imports are side-effect free and governance setup runs only via CLI execution.

* **Tests**
  * Added test coverage verifying that package imports do not trigger filesystem writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->