### PR TITLE
fix(ci): remove reserved secret mapping from limit-aware templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
   source.
 
 ### Fixed
+- **Reusable budget guard compatibility** — Removed explicit secret mapping in
+  generated limit-aware CI templates because the reusable workflow now consumes
+  `secrets.GITHUB_TOKEN` directly.
 - **IDP init import side effects** — Package root imports no longer trigger `forge-init` writes.
   `initProject` now lives in side-effect-free `patterns/idp/init/project.ts`, CLI execution in
   `patterns/idp/init/cli.ts` is entrypoint-guarded, and IDP barrel exports avoid CLI module

--- a/scripts/bootstrap/templates/workflows/limit-aware/ci-nextjs.yml.tpl
+++ b/scripts/bootstrap/templates/workflows/limit-aware/ci-nextjs.yml.tpl
@@ -36,8 +36,6 @@ jobs:
       monthly_cap_minutes: ${{ vars.ACTIONS_MONTHLY_CAP_MINUTES || '__ACTIONS_MONTHLY_CAP_MINUTES__' }}
       warn_pct: ${{ vars.ACTIONS_WARN_PCT || '__ACTIONS_WARN_PCT__' }}
       degrade_pct: ${{ vars.ACTIONS_DEGRADE_PCT || '__ACTIONS_DEGRADE_PCT__' }}
-    secrets:
-      github_token: ${{ secrets.GITHUB_TOKEN }}
 
   lint:
     name: Lint

--- a/scripts/bootstrap/templates/workflows/limit-aware/ci-node.yml.tpl
+++ b/scripts/bootstrap/templates/workflows/limit-aware/ci-node.yml.tpl
@@ -36,8 +36,6 @@ jobs:
       monthly_cap_minutes: ${{ vars.ACTIONS_MONTHLY_CAP_MINUTES || '__ACTIONS_MONTHLY_CAP_MINUTES__' }}
       warn_pct: ${{ vars.ACTIONS_WARN_PCT || '__ACTIONS_WARN_PCT__' }}
       degrade_pct: ${{ vars.ACTIONS_DEGRADE_PCT || '__ACTIONS_DEGRADE_PCT__' }}
-    secrets:
-      github_token: ${{ secrets.GITHUB_TOKEN }}
 
   lint:
     name: Lint

--- a/scripts/bootstrap/templates/workflows/limit-aware/ci-python.yml.tpl
+++ b/scripts/bootstrap/templates/workflows/limit-aware/ci-python.yml.tpl
@@ -36,8 +36,6 @@ jobs:
       monthly_cap_minutes: ${{ vars.ACTIONS_MONTHLY_CAP_MINUTES || '__ACTIONS_MONTHLY_CAP_MINUTES__' }}
       warn_pct: ${{ vars.ACTIONS_WARN_PCT || '__ACTIONS_WARN_PCT__' }}
       degrade_pct: ${{ vars.ACTIONS_DEGRADE_PCT || '__ACTIONS_DEGRADE_PCT__' }}
-    secrets:
-      github_token: ${{ secrets.GITHUB_TOKEN }}
 
   lint:
     name: Lint


### PR DESCRIPTION
## Summary
- remove explicit `secrets.github_token` mapping from limit-aware CI templates
- keep callers compatible with updated reusable budget guard in `Forge-Space/.github`
- avoid generated-workflow schema failures caused by reserved secret names

## Validation
- template YAML parse check for all `scripts/bootstrap/templates/workflows/limit-aware/*.yml.tpl`
- `npm run format:check -- CHANGELOG.md`
