### PR TITLE
feat: add security spoke v1 contract artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## [Unreleased]
 
 ### Added
+- **Security Spoke v1 contract** — Added canonical security-spoke artifacts
+  under `patterns/idp/security-spoke/`:
+  - JSON schema `security-spoke-report-v1.schema.json`
+  - app-native rule catalog `security-spoke-rules-v1.json`
+  - compatibility fixtures and contract tests for schema/enum stability
+  - TypeScript runtime guard and readers for shared report validation
 - **Limit-aware bootstrap templates** — Added workflow templates for `node`,
   `nextjs`, and `python` projects under
   `scripts/bootstrap/templates/workflows/limit-aware/`, including:

--- a/README.md
+++ b/README.md
@@ -131,6 +131,19 @@ npx forge-audit --json --threshold 60            # CI gate mode
 
 - [Scorecard Integration](docs/guides/scorecard-integration.md) — add quality scorecards to any repo
 - [Policy Engine Integration](docs/guides/policy-engine-integration.md) — add policy checks to any repo
+- [Security Spoke Contract v1](docs/guides/security-spoke-contract.md) — shared scanner output contract
+
+### Security Spoke Contract v1
+
+Security scanner outputs across Forge Space use the canonical v1 contract in
+`patterns/idp/security-spoke`.
+
+- Report schema:
+  `patterns/idp/security-spoke/schema/security-spoke-report-v1.schema.json`
+- Rule catalog:
+  `patterns/idp/security-spoke/rules/security-spoke-rules-v1.json`
+- Compatibility fixtures:
+  `patterns/idp/security-spoke/fixtures/*.json`
 
 ## � GitHub Workflows Optimization
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,7 @@
 - [User Guides](guides/) - Deployment and user journey guides
   - [Deployment Playbook](guides/DEPLOYMENT_PLAYBOOK.md)
   - [Developer Onboarding](guides/DEVELOPER_ONBOARDING.md)
+  - [Security Spoke Contract v1](guides/security-spoke-contract.md)
   - [Troubleshooting Guide](guides/TROUBLESHOOTING_GUIDE.md)
   - [User Journey](guides/USER_JOURNEY.md)
 - [Development Standards](standards/) - Coding and security standards

--- a/docs/guides/security-spoke-contract.md
+++ b/docs/guides/security-spoke-contract.md
@@ -1,0 +1,40 @@
+# Security Spoke Contract v1
+
+`@forgespace/core` is the canonical source for the Security Spoke v1 contract
+used by scanner emitters and consumers across Forge Space.
+
+## Contract artifacts
+
+- Report schema:
+  `patterns/idp/security-spoke/schema/security-spoke-report-v1.schema.json`
+- Rule catalog: `patterns/idp/security-spoke/rules/security-spoke-rules-v1.json`
+- Compatibility fixtures: `patterns/idp/security-spoke/fixtures/*.json`
+
+## Canonical finding fields
+
+Each finding payload includes:
+
+- `rule_id`
+- `severity`
+- `category`
+- `evidence`
+- `recommendation`
+- `risk_level`
+
+DAST telemetry is explicit in `dast.status` and remains hooks-only in v1.
+
+## TypeScript helpers
+
+The `patterns/idp/security-spoke` module exports:
+
+- contract enums for `severity`, `category`, and `risk_level`
+- report/catalog path constants
+- `isSecuritySpokeReportV1` runtime guard
+- schema/catalog readers
+
+## Compatibility guardrails
+
+- schema required fields are covered by contract tests
+- enum stability is covered by contract tests
+- fixture payloads are verified against the runtime guard
+- fixture findings are validated against rule catalog IDs

--- a/patterns/idp/__tests__/security-spoke-contract.test.ts
+++ b/patterns/idp/__tests__/security-spoke-contract.test.ts
@@ -1,0 +1,121 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  isSecuritySpokeReportV1,
+  readSecuritySpokeReportV1Schema,
+  readSecuritySpokeRuleCatalogV1,
+  SECURITY_SPOKE_CATEGORIES,
+  SECURITY_SPOKE_RISK_LEVELS,
+  SECURITY_SPOKE_SEVERITIES
+} from '../security-spoke/index.js';
+import type { SecuritySpokeReportV1 } from '../security-spoke/types.js';
+
+const baseDir = __dirname;
+const securitySpokeDir = path.join(baseDir, '..', 'security-spoke');
+const fixturesDir = path.join(securitySpokeDir, 'fixtures');
+
+function readJson(pathname: string): unknown {
+  return JSON.parse(fs.readFileSync(pathname, 'utf-8')) as unknown;
+}
+
+function readFixture(pathname: string): SecuritySpokeReportV1 {
+  return readJson(path.join(fixturesDir, pathname)) as SecuritySpokeReportV1;
+}
+
+describe('Security Spoke v1 contract', () => {
+  it('keeps required top-level fields stable', () => {
+    const schema = readSecuritySpokeReportV1Schema() as {
+      required?: string[];
+      properties?: Record<string, unknown>;
+    };
+
+    expect(schema.required).toEqual(
+      expect.arrayContaining([
+        'version',
+        'generated_at',
+        'scanner',
+        'summary',
+        'findings',
+        'dast'
+      ])
+    );
+
+    expect(schema.properties).toMatchObject({
+      version: expect.any(Object),
+      generated_at: expect.any(Object),
+      scanner: expect.any(Object),
+      summary: expect.any(Object),
+      findings: expect.any(Object),
+      dast: expect.any(Object)
+    });
+  });
+
+  it('keeps finding enums stable', () => {
+    const schema = readSecuritySpokeReportV1Schema() as {
+      properties?: {
+        findings?: {
+          items?: {
+            properties?: {
+              severity?: { enum?: string[] };
+              category?: { enum?: string[] };
+              risk_level?: { enum?: string[] };
+            };
+          };
+        };
+      };
+    };
+
+    const findingProperties = schema.properties?.findings?.items?.properties;
+
+    expect(findingProperties?.severity?.enum).toEqual(SECURITY_SPOKE_SEVERITIES);
+    expect(findingProperties?.category?.enum).toEqual(SECURITY_SPOKE_CATEGORIES);
+    expect(findingProperties?.risk_level?.enum).toEqual(SECURITY_SPOKE_RISK_LEVELS);
+  });
+
+  it('validates all report fixtures against runtime contract', () => {
+    const fixtureFiles = fs
+      .readdirSync(fixturesDir)
+      .filter((file) => file.endsWith('.json'))
+      .sort();
+
+    for (const file of fixtureFiles) {
+      const payload = readJson(path.join(fixturesDir, file));
+      expect(isSecuritySpokeReportV1(payload)).toBe(true);
+    }
+  });
+
+  it('keeps rule catalog IDs unique and enum-compatible', () => {
+    const catalog = readSecuritySpokeRuleCatalogV1();
+    const seenRuleIds = new Set<string>();
+
+    expect(catalog.version).toBe('v1');
+    expect(catalog.rules.length).toBeGreaterThan(0);
+
+    for (const rule of catalog.rules) {
+      expect(seenRuleIds.has(rule.rule_id)).toBe(false);
+      seenRuleIds.add(rule.rule_id);
+      expect(SECURITY_SPOKE_SEVERITIES).toContain(rule.severity);
+      expect(SECURITY_SPOKE_CATEGORIES).toContain(rule.category);
+      expect(SECURITY_SPOKE_RISK_LEVELS).toContain(rule.risk_level);
+      expect(rule.recommendation.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('keeps fixture finding rule IDs mapped to the catalog', () => {
+    const catalog = readSecuritySpokeRuleCatalogV1();
+    const validRuleIds = new Set(catalog.rules.map((rule) => rule.rule_id));
+    const findingsFixture = readFixture('security-spoke-report-v1.findings.json');
+
+    for (const finding of findingsFixture.findings) {
+      expect(validRuleIds.has(finding.rule_id)).toBe(true);
+    }
+  });
+
+  it('keeps fail-open fixture explicit for advisory mode', () => {
+    const failOpenFixture = readFixture('security-spoke-report-v1.fail-open.json');
+
+    expect(failOpenFixture.scanner.execution).toBe('error');
+    expect(failOpenFixture.summary.total_findings).toBe(0);
+    expect(failOpenFixture.dast.status).toBe('not_executed');
+  });
+});

--- a/patterns/idp/index.ts
+++ b/patterns/idp/index.ts
@@ -1,5 +1,6 @@
 export * from './feature-toggles/index.js';
 export * from './policy-engine/index.js';
 export * from './scorecards/index.js';
+export * from './security-spoke/index.js';
 export { initProject } from './init/project.js';
 export * from './migration/index.js';

--- a/patterns/idp/security-spoke/fixtures/security-spoke-report-v1.clean.json
+++ b/patterns/idp/security-spoke/fixtures/security-spoke-report-v1.clean.json
@@ -1,0 +1,30 @@
+{
+  "version": "v1",
+  "generated_at": "2026-03-11T03:00:00.000Z",
+  "scanner": {
+    "name": "forge-security-spoke",
+    "version": "1.0.0",
+    "execution": "success"
+  },
+  "summary": {
+    "total_findings": 0,
+    "by_severity": {
+      "critical": 0,
+      "high": 0,
+      "medium": 0,
+      "low": 0,
+      "info": 0
+    },
+    "by_risk_level": {
+      "high": 0,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "findings": [],
+  "dast": {
+    "status": "not_executed",
+    "mode": "hooks_only_v1",
+    "reason": "Security spoke v1 ships DAST hooks telemetry only."
+  }
+}

--- a/patterns/idp/security-spoke/fixtures/security-spoke-report-v1.fail-open.json
+++ b/patterns/idp/security-spoke/fixtures/security-spoke-report-v1.fail-open.json
@@ -1,0 +1,31 @@
+{
+  "version": "v1",
+  "generated_at": "2026-03-11T04:00:00.000Z",
+  "scanner": {
+    "name": "forge-security-spoke",
+    "version": "1.0.0",
+    "execution": "error",
+    "error_message": "native rules execution timed out"
+  },
+  "summary": {
+    "total_findings": 0,
+    "by_severity": {
+      "critical": 0,
+      "high": 0,
+      "medium": 0,
+      "low": 0,
+      "info": 0
+    },
+    "by_risk_level": {
+      "high": 0,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "findings": [],
+  "dast": {
+    "status": "not_executed",
+    "mode": "hooks_only_v1",
+    "reason": "DAST execution is tracked as hooks-only telemetry in v1."
+  }
+}

--- a/patterns/idp/security-spoke/fixtures/security-spoke-report-v1.findings.json
+++ b/patterns/idp/security-spoke/fixtures/security-spoke-report-v1.findings.json
@@ -1,0 +1,63 @@
+{
+  "version": "v1",
+  "generated_at": "2026-03-11T03:30:00.000Z",
+  "scanner": {
+    "name": "forge-security-spoke",
+    "version": "1.0.0",
+    "execution": "success"
+  },
+  "summary": {
+    "total_findings": 2,
+    "by_severity": {
+      "critical": 1,
+      "high": 1,
+      "medium": 0,
+      "low": 0,
+      "info": 0
+    },
+    "by_risk_level": {
+      "high": 2,
+      "medium": 0,
+      "low": 0
+    }
+  },
+  "findings": [
+    {
+      "rule_id": "SEC-SECRET-001",
+      "severity": "critical",
+      "category": "secrets",
+      "title": "Hardcoded Secret Pattern",
+      "evidence": [
+        {
+          "kind": "file",
+          "value": "AWS secret key-like token",
+          "file": "src/config.ts",
+          "line": 18
+        }
+      ],
+      "recommendation": "Remove hardcoded token, rotate credential, and use env injection.",
+      "risk_level": "high"
+    },
+    {
+      "rule_id": "SEC-INJ-001",
+      "severity": "high",
+      "category": "injection",
+      "title": "Injection Sink Pattern",
+      "evidence": [
+        {
+          "kind": "code",
+          "value": "string interpolation in SQL query",
+          "file": "src/repo/users.ts",
+          "line": 72
+        }
+      ],
+      "recommendation": "Replace dynamic SQL with parameterized query API.",
+      "risk_level": "high"
+    }
+  ],
+  "dast": {
+    "status": "not_executed",
+    "mode": "hooks_only_v1",
+    "reason": "DAST workers are deferred in security spoke v1."
+  }
+}

--- a/patterns/idp/security-spoke/index.ts
+++ b/patterns/idp/security-spoke/index.ts
@@ -1,0 +1,215 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type {
+  SecuritySpokeCategory,
+  SecuritySpokeDast,
+  SecuritySpokeEvidence,
+  SecuritySpokeFinding,
+  SecuritySpokeReportV1,
+  SecuritySpokeRiskLevel,
+  SecuritySpokeRuleCatalogV1,
+  SecuritySpokeScanner,
+  SecuritySpokeSeverity,
+  SecuritySpokeSummary
+} from './types.js';
+
+export * from './types.js';
+
+export const SECURITY_SPOKE_SEVERITIES: SecuritySpokeSeverity[] = [
+  'critical',
+  'high',
+  'medium',
+  'low',
+  'info'
+];
+
+export const SECURITY_SPOKE_CATEGORIES: SecuritySpokeCategory[] = [
+  'secrets',
+  'dependencies',
+  'injection',
+  'auth',
+  'transport',
+  'config',
+  'dast',
+  'other'
+];
+
+export const SECURITY_SPOKE_RISK_LEVELS: SecuritySpokeRiskLevel[] = ['high', 'medium', 'low'];
+
+const baseDir = __dirname;
+
+export const SECURITY_SPOKE_REPORT_V1_SCHEMA_PATH = path.join(
+  baseDir,
+  'schema',
+  'security-spoke-report-v1.schema.json'
+);
+
+export const SECURITY_SPOKE_RULE_CATALOG_V1_PATH = path.join(
+  baseDir,
+  'rules',
+  'security-spoke-rules-v1.json'
+);
+
+function parseJsonFile(pathname: string): unknown {
+  const content = fs.readFileSync(pathname, 'utf-8');
+  return JSON.parse(content) as unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function isStringEnumValue<T extends string>(value: unknown, enumValues: T[]): value is T {
+  return typeof value === 'string' && enumValues.includes(value as T);
+}
+
+function isEvidence(value: unknown): value is SecuritySpokeEvidence {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const kind = value.kind;
+  const file = value.file;
+  const line = value.line;
+
+  if (!isString(value.value)) {
+    return false;
+  }
+
+  if (!isStringEnumValue(kind, ['file', 'dependency', 'code', 'request', 'other'])) {
+    return false;
+  }
+
+  if (file !== undefined && typeof file !== 'string') {
+    return false;
+  }
+
+  if (line !== undefined && !Number.isInteger(line)) {
+    return false;
+  }
+
+  return true;
+}
+
+function isFinding(value: unknown): value is SecuritySpokeFinding {
+  if (!isRecord(value) || !Array.isArray(value.evidence)) {
+    return false;
+  }
+
+  if (!isString(value.rule_id) || !isString(value.title)) {
+    return false;
+  }
+
+  if (!isString(value.recommendation)) {
+    return false;
+  }
+
+  if (!isStringEnumValue(value.severity, SECURITY_SPOKE_SEVERITIES)) {
+    return false;
+  }
+
+  if (!isStringEnumValue(value.category, SECURITY_SPOKE_CATEGORIES)) {
+    return false;
+  }
+
+  if (!isStringEnumValue(value.risk_level, SECURITY_SPOKE_RISK_LEVELS)) {
+    return false;
+  }
+
+  return value.evidence.every(isEvidence);
+}
+
+function isSummary(value: unknown): value is SecuritySpokeSummary {
+  if (!isRecord(value) || !isRecord(value.by_severity) || !isRecord(value.by_risk_level)) {
+    return false;
+  }
+
+  const summary = value as {
+    total_findings: unknown;
+    by_severity: Record<string, unknown>;
+    by_risk_level: Record<string, unknown>;
+  };
+
+  if (!Number.isInteger(summary.total_findings)) {
+    return false;
+  }
+
+  if ((summary.total_findings as number) < 0) {
+    return false;
+  }
+
+  const bySeverityValid = SECURITY_SPOKE_SEVERITIES.every(severity =>
+    Number.isInteger(summary.by_severity[severity])
+  );
+  const byRiskValid = SECURITY_SPOKE_RISK_LEVELS.every(risk =>
+    Number.isInteger(summary.by_risk_level[risk])
+  );
+
+  return bySeverityValid && byRiskValid;
+}
+
+function isScanner(value: unknown): value is SecuritySpokeScanner {
+  if (!isRecord(value) || !isString(value.name) || !isString(value.version)) {
+    return false;
+  }
+
+  if (!isStringEnumValue(value.execution, ['success', 'error'])) {
+    return false;
+  }
+
+  if (value.error_message !== undefined && typeof value.error_message !== 'string') {
+    return false;
+  }
+
+  return true;
+}
+
+function isDast(value: unknown): value is SecuritySpokeDast {
+  if (!isRecord(value) || !isString(value.reason)) {
+    return false;
+  }
+
+  if (
+    !isStringEnumValue(value.status, [
+      'not_executed',
+      'scheduled',
+      'running',
+      'completed',
+      'failed'
+    ])
+  ) {
+    return false;
+  }
+
+  return isStringEnumValue(value.mode, ['hooks_only_v1', 'full']);
+}
+
+export function isSecuritySpokeReportV1(value: unknown): value is SecuritySpokeReportV1 {
+  if (!isRecord(value) || value.version !== 'v1' || !Array.isArray(value.findings)) {
+    return false;
+  }
+
+  if (!isString(value.generated_at)) {
+    return false;
+  }
+
+  if (!isScanner(value.scanner) || !isSummary(value.summary) || !isDast(value.dast)) {
+    return false;
+  }
+
+  return value.findings.every(isFinding);
+}
+
+export function readSecuritySpokeReportV1Schema(): Record<string, unknown> {
+  const schema = parseJsonFile(SECURITY_SPOKE_REPORT_V1_SCHEMA_PATH);
+  return (isRecord(schema) ? schema : {}) as Record<string, unknown>;
+}
+
+export function readSecuritySpokeRuleCatalogV1(): SecuritySpokeRuleCatalogV1 {
+  const catalog = parseJsonFile(SECURITY_SPOKE_RULE_CATALOG_V1_PATH);
+  return (catalog as SecuritySpokeRuleCatalogV1) ?? { version: 'v1', updated_at: '', rules: [] };
+}

--- a/patterns/idp/security-spoke/rules/security-spoke-rules-v1.json
+++ b/patterns/idp/security-spoke/rules/security-spoke-rules-v1.json
@@ -1,0 +1,76 @@
+{
+  "version": "v1",
+  "updated_at": "2026-03-11T00:00:00.000Z",
+  "rules": [
+    {
+      "rule_id": "SEC-SECRET-001",
+      "title": "Hardcoded Secret Pattern",
+      "description": "Detected token-like secret material committed in source files.",
+      "severity": "critical",
+      "category": "secrets",
+      "recommendation": "Remove the value, rotate exposed credentials, and load from environment.",
+      "risk_level": "high",
+      "tags": ["secrets", "credentials", "sast"]
+    },
+    {
+      "rule_id": "SEC-DEP-001",
+      "title": "Known Vulnerable Dependency",
+      "description": "Dependency version is flagged by the native advisory dataset.",
+      "severity": "high",
+      "category": "dependencies",
+      "recommendation": "Upgrade to a patched version and regenerate lockfiles.",
+      "risk_level": "high",
+      "tags": ["dependencies", "supply-chain", "sast"]
+    },
+    {
+      "rule_id": "SEC-INJ-001",
+      "title": "Injection Sink Pattern",
+      "description": "Potential command or SQL injection sink detected without sanitization.",
+      "severity": "high",
+      "category": "injection",
+      "recommendation": "Use parameterized APIs and sanitize untrusted inputs.",
+      "risk_level": "high",
+      "tags": ["injection", "owasp", "sast"]
+    },
+    {
+      "rule_id": "SEC-AUTH-001",
+      "title": "Missing Authorization Guard",
+      "description": "Sensitive code path appears to execute without access control checks.",
+      "severity": "medium",
+      "category": "auth",
+      "recommendation": "Add explicit authorization checks at the system boundary.",
+      "risk_level": "medium",
+      "tags": ["auth", "access-control", "sast"]
+    },
+    {
+      "rule_id": "SEC-TRANSPORT-001",
+      "title": "Insecure Transport Usage",
+      "description": "Plain HTTP endpoint usage detected for potentially sensitive traffic.",
+      "severity": "medium",
+      "category": "transport",
+      "recommendation": "Enforce HTTPS and reject insecure URL schemes in production flows.",
+      "risk_level": "medium",
+      "tags": ["transport", "tls", "sast"]
+    },
+    {
+      "rule_id": "SEC-CONFIG-001",
+      "title": "Overly Permissive Security Config",
+      "description": "Permissive CORS or security headers configuration detected.",
+      "severity": "medium",
+      "category": "config",
+      "recommendation": "Restrict origins/headers and apply environment-specific allowlists.",
+      "risk_level": "medium",
+      "tags": ["config", "cors", "sast"]
+    },
+    {
+      "rule_id": "SEC-DAST-001",
+      "title": "DAST Hook Telemetry",
+      "description": "DAST execution is not part of v1 and is tracked as telemetry only.",
+      "severity": "info",
+      "category": "dast",
+      "recommendation": "Review hook status and schedule DAST worker rollout separately.",
+      "risk_level": "low",
+      "tags": ["dast", "hooks", "telemetry"]
+    }
+  ]
+}

--- a/patterns/idp/security-spoke/schema/security-spoke-report-v1.schema.json
+++ b/patterns/idp/security-spoke/schema/security-spoke-report-v1.schema.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://forgespace.co/schemas/security-spoke-report-v1.schema.json",
+  "title": "SecuritySpokeReportV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "generated_at",
+    "scanner",
+    "summary",
+    "findings",
+    "dast"
+  ],
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "v1"
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "scanner": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version", "execution"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 },
+        "execution": {
+          "type": "string",
+          "enum": ["success", "error"]
+        },
+        "error_message": { "type": "string" }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["total_findings", "by_severity", "by_risk_level"],
+      "properties": {
+        "total_findings": { "type": "integer", "minimum": 0 },
+        "by_severity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["critical", "high", "medium", "low", "info"],
+          "properties": {
+            "critical": { "type": "integer", "minimum": 0 },
+            "high": { "type": "integer", "minimum": 0 },
+            "medium": { "type": "integer", "minimum": 0 },
+            "low": { "type": "integer", "minimum": 0 },
+            "info": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "by_risk_level": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["high", "medium", "low"],
+          "properties": {
+            "high": { "type": "integer", "minimum": 0 },
+            "medium": { "type": "integer", "minimum": 0 },
+            "low": { "type": "integer", "minimum": 0 }
+          }
+        }
+      }
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "rule_id",
+          "severity",
+          "category",
+          "title",
+          "evidence",
+          "recommendation",
+          "risk_level"
+        ],
+        "properties": {
+          "rule_id": { "type": "string", "minLength": 1 },
+          "severity": {
+            "type": "string",
+            "enum": ["critical", "high", "medium", "low", "info"]
+          },
+          "category": {
+            "type": "string",
+            "enum": [
+              "secrets",
+              "dependencies",
+              "injection",
+              "auth",
+              "transport",
+              "config",
+              "dast",
+              "other"
+            ]
+          },
+          "title": { "type": "string", "minLength": 1 },
+          "evidence": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["kind", "value"],
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "enum": ["file", "dependency", "code", "request", "other"]
+                },
+                "value": { "type": "string", "minLength": 1 },
+                "file": { "type": "string" },
+                "line": { "type": "integer", "minimum": 1 }
+              }
+            }
+          },
+          "recommendation": { "type": "string", "minLength": 1 },
+          "risk_level": { "type": "string", "enum": ["high", "medium", "low"] }
+        }
+      }
+    },
+    "dast": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "mode", "reason"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["not_executed", "scheduled", "running", "completed", "failed"]
+        },
+        "mode": {
+          "type": "string",
+          "enum": ["hooks_only_v1", "full"]
+        },
+        "reason": { "type": "string", "minLength": 1 }
+      }
+    }
+  }
+}

--- a/patterns/idp/security-spoke/types.ts
+++ b/patterns/idp/security-spoke/types.ts
@@ -1,0 +1,86 @@
+export type SecuritySpokeSchemaVersion = 'v1';
+
+export type SecuritySpokeSeverity = 'critical' | 'high' | 'medium' | 'low' | 'info';
+
+export type SecuritySpokeCategory =
+  | 'secrets'
+  | 'dependencies'
+  | 'injection'
+  | 'auth'
+  | 'transport'
+  | 'config'
+  | 'dast'
+  | 'other';
+
+export type SecuritySpokeRiskLevel = 'high' | 'medium' | 'low';
+
+export type SecuritySpokeDastStatus =
+  | 'not_executed'
+  | 'scheduled'
+  | 'running'
+  | 'completed'
+  | 'failed';
+
+export type SecuritySpokeDastMode = 'hooks_only_v1' | 'full';
+
+export interface SecuritySpokeEvidence {
+  kind: 'file' | 'dependency' | 'code' | 'request' | 'other';
+  value: string;
+  file?: string;
+  line?: number;
+}
+
+export interface SecuritySpokeFinding {
+  rule_id: string;
+  severity: SecuritySpokeSeverity;
+  category: SecuritySpokeCategory;
+  title: string;
+  evidence: SecuritySpokeEvidence[];
+  recommendation: string;
+  risk_level: SecuritySpokeRiskLevel;
+}
+
+export interface SecuritySpokeSummary {
+  total_findings: number;
+  by_severity: Record<SecuritySpokeSeverity, number>;
+  by_risk_level: Record<SecuritySpokeRiskLevel, number>;
+}
+
+export interface SecuritySpokeDast {
+  status: SecuritySpokeDastStatus;
+  mode: SecuritySpokeDastMode;
+  reason: string;
+}
+
+export interface SecuritySpokeScanner {
+  name: string;
+  version: string;
+  execution: 'success' | 'error';
+  error_message?: string;
+}
+
+export interface SecuritySpokeReportV1 {
+  version: SecuritySpokeSchemaVersion;
+  generated_at: string;
+  scanner: SecuritySpokeScanner;
+  summary: SecuritySpokeSummary;
+  findings: SecuritySpokeFinding[];
+  dast: SecuritySpokeDast;
+}
+
+export interface SecuritySpokeRule {
+  rule_id: string;
+  title: string;
+  description: string;
+  severity: SecuritySpokeSeverity;
+  category: SecuritySpokeCategory;
+  recommendation: string;
+  risk_level: SecuritySpokeRiskLevel;
+  tags: string[];
+}
+
+export interface SecuritySpokeRuleCatalogV1 {
+  version: SecuritySpokeSchemaVersion;
+  updated_at: string;
+  rules: SecuritySpokeRule[];
+}


### PR DESCRIPTION
## Summary
- add canonical Security Spoke v1 contract under patterns/idp/security-spoke
- include JSON schema, app-native rule catalog, and report fixtures
- export TS types/runtime guard/readers and add contract compatibility tests
- document shared contract source-of-truth in README/docs and changelog

## Validation
- npm run build
- npm test -- patterns/idp/__tests__/security-spoke-contract.test.ts
- npm run format:check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Security Spoke Contract v1 for standardized security assessment report formatting and validation across tools.
  * Added 7 predefined security rules for detecting hardcoded secrets, vulnerable dependencies, injection vulnerabilities, authorization gaps, insecure transport, and configuration issues.

* **Documentation**
  * Added comprehensive documentation and guides for Security Spoke Contract v1, including schema specifications, rule catalogs, and compatibility standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->