### PR TITLE
feat(shared-constants): add MCP_UI_SERVER_NAME, deprecate MCP_UIFORGE_SERVER_NAME

### DIFF
--- a/patterns/shared-constants/__tests__/index.test.ts
+++ b/patterns/shared-constants/__tests__/index.test.ts
@@ -74,6 +74,7 @@ describe('Shared Constants Index', () => {
 
     it('should export all MCP protocol constants', () => {
       expect(SharedConstants.MCP_UIFORGE_SERVER_NAME).toBeDefined();
+      expect(SharedConstants.MCP_UI_SERVER_NAME).toBeDefined();
     });
 
     it('should export all environment constants', () => {

--- a/patterns/shared-constants/__tests__/mcp-protocol.test.ts
+++ b/patterns/shared-constants/__tests__/mcp-protocol.test.ts
@@ -11,6 +11,7 @@ import {
   MCP_SERVER_VERSION,
   MCP_GATEWAY_CLIENT_NAME,
   MCP_UIFORGE_SERVER_NAME,
+  MCP_UI_SERVER_NAME,
   MCP_PROTOCOL_METHODS,
   type McpProtocolMethod
 } from '../mcp-protocol';
@@ -32,6 +33,11 @@ describe('MCP Protocol Constants', () => {
       expect(MCP_UIFORGE_SERVER_NAME).toBe('uiforge');
       expect(typeof MCP_GATEWAY_CLIENT_NAME).toBe('string');
       expect(typeof MCP_UIFORGE_SERVER_NAME).toBe('string');
+    });
+
+    it('MCP_UI_SERVER_NAME should be the canonical Forge Space server name', () => {
+      expect(MCP_UI_SERVER_NAME).toBe('forge-ui');
+      expect(typeof MCP_UI_SERVER_NAME).toBe('string');
     });
   });
 

--- a/patterns/shared-constants/mcp-protocol.ts
+++ b/patterns/shared-constants/mcp-protocol.ts
@@ -10,7 +10,11 @@ export const MCP_SERVER_VERSION = '0.1.0';
 
 export const MCP_GATEWAY_CLIENT_NAME = 'forge-mcp-gateway-client';
 
+/** @deprecated Use MCP_UI_SERVER_NAME instead */
 export const MCP_UIFORGE_SERVER_NAME = 'uiforge';
+
+/** Canonical name for the UI generation MCP server (ui-mcp) */
+export const MCP_UI_SERVER_NAME = 'forge-ui';
 
 export const MCP_PROTOCOL_METHODS = {
   TOOLS_LIST: 'tools/list',


### PR DESCRIPTION
## Summary

Add `MCP_UI_SERVER_NAME` as the canonical Forge Space name for the UI generation MCP server, with a backwards-compatible deprecation of the stale `MCP_UIFORGE_SERVER_NAME`.

## Changes

**`patterns/shared-constants/mcp-protocol.ts`**
```ts
/** @deprecated Use MCP_UI_SERVER_NAME instead */
export const MCP_UIFORGE_SERVER_NAME = 'uiforge';

/** Canonical name for the UI generation MCP server (ui-mcp) */
export const MCP_UI_SERVER_NAME = 'forge-ui';
```

**Tests**
- New: `MCP_UI_SERVER_NAME should be the canonical Forge Space server name`
- Updated index test: `MCP_UI_SERVER_NAME` exported from barrel

## Why Backwards-Compatible

`MCP_UIFORGE_SERVER_NAME` is kept with a `@deprecated` JSDoc tag so existing consumers don't break. They can migrate to `MCP_UI_SERVER_NAME` at their own pace.

## Metrics

| Metric | Before | After |
|--------|--------|-------|
| Tests | 599 | **600** |
| Old constant | `'uiforge'` | `'uiforge'` (kept, deprecated) |
| New constant | — | `MCP_UI_SERVER_NAME = 'forge-ui'` |