### PR TITLE
ci: auto-detect tenant profile from .forge/tenant-profile.yml in git hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,8 +5,17 @@ echo "⚙️  [test-autogen] pre-commit (phase0 warn)"
 TENANT_ID="${FORGE_TENANT_ID:-}"
 TENANT_PROFILE_REF="${FORGE_TENANT_PROFILE_REF:-}"
 
+# Auto-detect from inline config when env vars are not set
+INLINE_PROFILE=".forge/tenant-profile.yml"
+if [ -z "$TENANT_ID" ] && [ -f "$INLINE_PROFILE" ]; then
+  TENANT_ID=$(grep '^tenant_id:' "$INLINE_PROFILE" | awk '{print $2}' || true)
+fi
+if [ -z "$TENANT_PROFILE_REF" ] && [ -f "$INLINE_PROFILE" ]; then
+  TENANT_PROFILE_REF="$INLINE_PROFILE"
+fi
+
 if [ -z "$TENANT_ID" ] || [ -z "$TENANT_PROFILE_REF" ]; then
-  echo "⚠️  FORGE_TENANT_ID/FORGE_TENANT_PROFILE_REF ausentes; pulando test-autogen (warn-only)."
+  echo "⚠️  FORGE_TENANT_ID/FORGE_TENANT_PROFILE_REF ausentes e .forge/tenant-profile.yml nao encontrado; pulando test-autogen (warn-only)."
   exit 0
 fi
 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -5,8 +5,17 @@ echo "⚙️  [test-autogen] pre-push (phase0 warn)"
 TENANT_ID="${FORGE_TENANT_ID:-}"
 TENANT_PROFILE_REF="${FORGE_TENANT_PROFILE_REF:-}"
 
+# Auto-detect from inline config when env vars are not set
+INLINE_PROFILE=".forge/tenant-profile.yml"
+if [ -z "$TENANT_ID" ] && [ -f "$INLINE_PROFILE" ]; then
+  TENANT_ID=$(grep '^tenant_id:' "$INLINE_PROFILE" | awk '{print $2}' || true)
+fi
+if [ -z "$TENANT_PROFILE_REF" ] && [ -f "$INLINE_PROFILE" ]; then
+  TENANT_PROFILE_REF="$INLINE_PROFILE"
+fi
+
 if [ -z "$TENANT_ID" ] || [ -z "$TENANT_PROFILE_REF" ]; then
-  echo "⚠️  FORGE_TENANT_ID/FORGE_TENANT_PROFILE_REF ausentes; pulando test-autogen (warn-only)."
+  echo "⚠️  FORGE_TENANT_ID/FORGE_TENANT_PROFILE_REF e .forge/tenant-profile.yml ausentes; pulando test-autogen (warn-only)."
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

- Pre-commit and pre-push hooks now read `.forge/tenant-profile.yml` as a fallback when `FORGE_TENANT_ID` / `FORGE_TENANT_PROFILE_REF` env vars are not set
- Eliminates the recurring `⚠️ FORGE_TENANT_ID/FORGE_TENANT_PROFILE_REF ausentes` warning on every local commit/push (present since the project was created — fixed now that PR #142 inlined the tenant profile)

## Before

```
⚙️  [test-autogen] pre-commit (phase0 warn)
⚠️  FORGE_TENANT_ID/FORGE_TENANT_PROFILE_REF ausentes; pulando test-autogen (warn-only).
```

## After

```
⚙️  [test-autogen] pre-commit (phase0 warn)
{"passed": true, "stack": "node", "requirements": [], ...}
```

## Changes

- `.husky/pre-commit`: auto-detect `tenant_id` from `.forge/tenant-profile.yml` when env vars unset
- `.husky/pre-push`: same auto-detection logic

No behavior change for repos that explicitly set `FORGE_TENANT_ID` / `FORGE_TENANT_PROFILE_REF` env vars — those still take precedence.