### PR TITLE
chore: add FUNDING.yml for GitHub Sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+# GitHub Sponsors funding configuration
+github: [Forge-Space]


### PR DESCRIPTION
Adds GitHub Sponsors funding configuration to enable the GitHub Sponsors program and match eligible donations.