### PR TITLE
chore(release): v1.12.3 — CI hygiene, rebrand, tenant profile inline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 ## [Unreleased]
 
+## [1.12.3] - 2026-03-15
+
+### Changed
+- **CI hygiene**: `actions/checkout` and `actions/setup-node` upgraded **v4 → v6**
+  across all 13 reusable workflow files (40 references), eliminating Node.js 20
+  deprecation warnings ahead of the June 2026 deadline (#143).
+- **Tenant profile inlined**: `.forge/tenant-profile.yml` committed directly into the
+  repo, eliminating the fragile cross-repo PAT checkout (`FORGE_TENANT_PROFILES_READ_TOKEN`)
+  that silently skipped the `test-autogen-warn` CI job on token expiry (#142).
+- **Git hooks auto-detect tenant profile**: pre-commit and pre-push hooks now read
+  `.forge/tenant-profile.yml` as fallback when `FORGE_TENANT_ID`/`FORGE_TENANT_PROFILE_REF`
+  env vars are unset — eliminates the recurring "ausentes" warning (#144).
+- **Complete UIForge → Forge Space rebrand** in scripts, patterns, and Serena memories:
+  `ForgeSpaceFeatureToggles` (canonical), `UIForgeFeatureToggles` (backwards-compat alias),
+  `integrate.js` canonical project names (`ui-mcp`, `siza`), 8 stale `knip.json` ignores
+  removed (#141).
+
+### Added
+- **`.forge/tenant-profile.yml`**: Inline tenant configuration (no secrets) for
+  CI and git hooks without requiring cross-repo access (#142).
+- **`.github/FUNDING.yml`**: GitHub Sponsors configuration.
+
+### Fixed
+- **knip.json**: Removed 8 stale `patterns/**` ignore entries that matched no files
+  in the project scope; `knip` now reports 0 issues with no configuration hints (#141).
+
+### Infrastructure
+- **`.forge/test-autogen-telemetry.jsonl`** and **`.forge/test-autogen-baseline.json`**
+  added to `.gitignore` — these are ephemeral hook runtime artifacts (#145).
+
 ## [1.12.0] - 2026-03-15
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@forgespace/core",
-  "version": "1.12.0",
+  "version": "1.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@forgespace/core",
-      "version": "1.12.0",
+      "version": "1.12.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgespace/core",
-  "version": "1.12.0",
+  "version": "1.12.3",
   "description": "Shared configuration, workflows, and architectural patterns for the Forgespace ecosystem",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@
  */
 
 // Version information — kept in sync with package.json by scripts/release-core.sh
-export const VERSION = '1.12.0';
+export const VERSION = '1.12.3';
 
 // Type definitions
 export interface ProjectConfig {


### PR DESCRIPTION
## Release v1.12.3

Batch of CI hygiene and rebrand improvements from PRs #141–145.

## Changes

### CI / Infrastructure
- **actions v4→v6** (#143): `actions/checkout` and `actions/setup-node` upgraded across 13 reusable workflow files (40 references) — eliminates Node.js 20 deprecation warnings before the June 2026 forced cutover
- **Tenant profile inlined** (#142): `.forge/tenant-profile.yml` committed directly; eliminates `FORGE_TENANT_PROFILES_READ_TOKEN` dependency and the silent CI skip on token expiry
- **Git hooks auto-detect** (#144): pre-commit/pre-push now read `.forge/tenant-profile.yml` as fallback — eliminates recurring `FORGE_TENANT_ID/FORGE_TENANT_PROFILE_REF ausentes` warning on every local commit

### Chore / Rebrand
- **UIForge → Forge Space** (#141): Complete rename in scripts, patterns, Serena memories; `ForgeSpaceFeatureToggles` canonical, `UIForgeFeatureToggles` backwards-compat alias; 8 stale `knip.json` ignores removed
- **`.gitignore`** (#145): `.forge/test-autogen-*.json*` runtime artifacts ignored

### Version
- `package.json`: `1.12.0` → `1.12.3`
- `src/index.ts` VERSION constant: `'1.12.0'` → `'1.12.3'`

## Quality
- Build: ✅ tsc passes
- Tests: ✅ 609/609
- Knip: ✅ 0 issues