### PR TITLE
chore(release): v1.13.0 — NLnet funding ops automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## [Unreleased]
 
+## [1.13.0] - 2026-03-16
+
+### Added
+- **NLnet funding ops automation**: `ops/funding/nlnet/project.json` manifest (NGI Zero Commons Fund, €40k, 6 months), applicant overlay template, render/check scripts, and weekly GitHub Actions cron that creates/updates a funding-status issue with labels `funding-ops` + `automated` (#150).
+- **ESLint `.cjs` coverage**: extended `eslint.config.js` to apply all globals and rules to `.cjs` files, fixing lint errors in the new funding scripts (#150).
+
+### Changed
+- **README**: Added npm version badge alongside existing CI, License, TypeScript, and PRs Welcome badges (#149).
+
 ## [1.12.3] - 2026-03-15
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@forgespace/core",
-  "version": "1.12.3",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@forgespace/core",
-      "version": "1.12.3",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgespace/core",
-  "version": "1.12.3",
+  "version": "1.13.0",
   "description": "Shared configuration, workflows, and architectural patterns for the Forgespace ecosystem",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@
  */
 
 // Version information — kept in sync with package.json by scripts/release-core.sh
-export const VERSION = '1.12.3';
+export const VERSION = '1.13.0';
 
 // Type definitions
 export interface ProjectConfig {


### PR DESCRIPTION
## v1.13.0 Release

### Added
- **NLnet funding ops automation**: \`ops/funding/nlnet/project.json\` manifest (NGI Zero Commons Fund, €40k, 6 months), applicant overlay template, render/check scripts, and weekly GitHub Actions cron that creates/updates a funding-status issue with labels \`funding-ops\` + \`automated\` (#150).
- **ESLint \`.cjs\` coverage**: extended \`eslint.config.js\` to apply all globals and rules to \`.cjs\` files, fixing lint errors in the new funding scripts (#150).

### Changed
- **README**: Added npm version badge alongside existing CI, License, TypeScript, and PRs Welcome badges (#149).

---
This is the release PR that bumps `package.json`, `src/index.ts VERSION`, and `CHANGELOG.md` to `v1.13.0`.