### PR TITLE
chore: gitignore auto-generated test stubs from forge-ai-init hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,10 @@ test.local.js
 ops/funding/nlnet/applicant.local.json
 ops/funding/nlnet/generated/
 
+# Auto-generated test stubs (forge-ai-init test-autogen pre-commit hook)
+tests/unit/
+tests/integration/
+
 # Cache
 .cache/
 .pytest_cache/


### PR DESCRIPTION
## Summary

The `forge-ai-init test-autogen` pre-commit hook auto-generates stub test files under `tests/unit/` and `tests/integration/` when production code changes. These files contain only `expect(true).toBe(true)` placeholders and accumulate in the working tree without ever being committed.

Add these paths to `.gitignore` to prevent the stubs from polluting `git status` output.

## Changes

- `.gitignore`: add `tests/unit/` and `tests/integration/` entries

## Why not commit the stubs?

The pre-commit hook creates them as reminders to add real tests. Committing placeholder stubs would reduce coverage signal and inflate test counts. They should be written properly or deleted, not tracked.