### PR TITLE
chore(knip): remove @jest/globals unused dep and unexport InitResult

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "forge-audit": "dist/patterns/idp/migration/cli.js"
   },
   "dependencies": {
-    "@jest/globals": "^30.3.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "chalk": "^5.3.0",
     "commander": "^14.0.3",

--- a/patterns/idp/init/project.ts
+++ b/patterns/idp/init/project.ts
@@ -116,7 +116,7 @@ jobs:
 `;
 }
 
-export interface InitResult {
+interface InitResult {
   created: string[];
   skipped: string[];
 }


### PR DESCRIPTION
## Summary

Resolves 2 knip warnings that were surfacing in static analysis:

1. **`@jest/globals` unused dependency** — removed from `package.json`. Tests use Jest globals implicitly via ts-jest/jest config, not via explicit import from `@jest/globals`.

2. **`InitResult` unexported** — removed `export` from `interface InitResult` in `patterns/idp/init/project.ts`. The type is only used internally; `cli.ts` defines its own identical `interface InitResult` locally.

## Verification

- `npx knip`: 0 issues
- `npm run validate`: pass
- `npm test`: 652 tests pass (27 suites)
- `tsc`: 0 errors