### PR TITLE
chore(docs): rebrand UIForge → Forge Space across 14 pattern READMEs

### DIFF
--- a/patterns/config/README.md
+++ b/patterns/config/README.md
@@ -28,8 +28,8 @@ feature_toggles:
   global_features: true
   project_namespaces:
     mcp-gateway: "mcp-gateway"
-    uiforge-mcp: "uiforge-mcp"
-    uiforge-webapp: "uiforge-webapp"
+    ui-mcp: "ui-mcp"
+    siza: "siza"
 ```
 
 ## Usage
@@ -38,8 +38,8 @@ This config is read by the integration scripts when pushing patterns to downstre
 
 ```bash
 npm run integrate:mcp-gateway   # Uses this config to determine which patterns to push
-npm run integrate:uiforge-mcp
-npm run integrate:uiforge-webapp
+npm run integrate:ui-mcp
+npm run integrate:siza
 ```
 
 See `patterns/feature-toggles/README.md` for the Unleash integration details.

--- a/patterns/coverage/coverage-standards.md
+++ b/patterns/coverage/coverage-standards.md
@@ -105,8 +105,8 @@ echo "✅ Coverage $COVERAGE% meets 80% threshold"
 ```bash
 #!/bin/bash
 # Compare coverage across projects
-echo "Comparing coverage across UIForge projects..."
-for project in mcp-gateway uiforge-webapp uiforge-mcp; do
+echo "Comparing coverage across Forge Space projects..."
+for project in mcp-gateway siza ui-mcp; do
   echo "📊 $project coverage:"
   cd "/path/to/$project"
   npm run test:coverage -- --coverageReporters=json | jq '.total.lines.pct'
@@ -121,8 +121,8 @@ done
 
 ## Project Coverage Summary
 - **mcp-gateway**: X% (status: ✅/⚠️/❌)
-- **uiforge-webapp**: X% (status: ✅/⚠️/❌)
-- **uiforge-mcp**: X% (status: ✅/⚠️/❌)
+- **siza**: X% (status: ✅/⚠️/❌)
+- **ui-mcp**: X% (status: ✅/⚠️/❌)
 
 ## Coverage Trends
 - Overall trend: ↗️/↘️/➡️

--- a/patterns/docker/README.md
+++ b/patterns/docker/README.md
@@ -1,8 +1,8 @@
-# UIForge Docker Patterns
+# Forge Space Docker Patterns
 
-## 🐳 Docker Standards for UIForge Projects
+## 🐳 Docker Standards for Forge Space Projects
 
-This directory contains Docker patterns and configurations for consistent containerization across all UIForge projects.
+This directory contains Docker patterns and configurations for consistent containerization across all Forge Space projects.
 
 ## 📋 Available Patterns
 
@@ -62,7 +62,7 @@ docker-compose up -d dev
 
 ### Production Build
 ```bash
-docker build -t uiforge/app:latest .
+docker build -t forgespace/app:latest .
 ```
 
 ### Testing Environment

--- a/patterns/feature-toggles/README.md
+++ b/patterns/feature-toggles/README.md
@@ -1,10 +1,10 @@
-# Centralized Feature Toggle System for UIForge Ecosystem
+# Centralized Feature Toggle System for Forge Space Ecosystem
 
 Cross-project feature management with Unleash for unified control.
 
 ## 🎯 Overview
 
-This directory contains a centralized feature toggle system designed to manage features across the entire UIForge ecosystem (MCP Gateway, UIForge MCP, UIForge WebApp). The system uses self-hosted Unleash with zero licensing costs and provides unified feature management capabilities across all projects.
+This directory contains a centralized feature toggle system designed to manage features across the entire Forge Space ecosystem (MCP Gateway, Forge UI MCP, Forge Space WebApp). The system uses self-hosted Unleash with zero licensing costs and provides unified feature management capabilities across all projects.
 
 ## 📋 Available Patterns
 
@@ -64,17 +64,17 @@ open http://localhost:4242
 # Create default admin user
 curl -X POST http://localhost:4242/api/admin/users \
   -H "Content-Type: application/json" \
-  -d '{"email":"admin@uiforge.local","name":"Admin User"}'
+  -d '{"email":"admin@forgespace.local","name":"Admin User"}'
 
 # Create API token
 curl -X POST http://localhost:4242/api/admin/api-tokens \
   -H "Content-Type: application/json" \
-  -d '{"name":"uiforge-token","type":"CLIENT"}'
+  -d '{"name":"forgespace-token","type":"CLIENT"}'
 ```
 
 ### Centralized Feature Management CLI
 
-The `forge-features` CLI tool provides centralized management of features across all UIForge projects:
+The `forge-features` CLI tool provides centralized management of features across all Forge Space projects:
 
 ```bash
 # Enable global features (affects all projects)
@@ -83,8 +83,8 @@ forge-features enable global.beta-features
 
 # Enable project-specific features
 forge-features enable mcp-gateway.rate-limiting
-forge-features enable uiforge-mcp.ai-chat
-forge-features enable uiforge-webapp.dark-mode
+forge-features enable ui-mcp.ai-chat
+forge-features enable siza.dark-mode
 
 # Disable features
 forge-features disable global.experimental-ui
@@ -102,8 +102,8 @@ forge-features list
 
 - **Global Features**: `global.debug-mode`, `global.beta-features`, `global.experimental-ui`, `global.enhanced-logging`
 - **MCP Gateway**: `mcp-gateway.rate-limiting`, `mcp-gateway.request-validation`, `mcp-gateway.security-headers`
-- **UIForge MCP**: `uiforge-mcp.ai-chat`, `uiforge-mcp.template-management`, `uiforge-mcp.ui-generation`
-- **UIForge WebApp**: `uiforge-webapp.dark-mode`, `uiforge-webapp.advanced-analytics`, `uiforge-webapp.experimental-components`
+- **Forge UI MCP**: `ui-mcp.ai-chat`, `ui-mcp.template-management`, `ui-mcp.ui-generation`
+- **Forge Space WebApp**: `siza.dark-mode`, `siza.advanced-analytics`, `siza.experimental-components`
 
 ## 📁 Pattern Structure
 
@@ -125,12 +125,12 @@ patterns/feature-toggles/
 // libraries/nodejs/feature-toggles.js
 const { UnleashClient } = require('unleash-client-node');
 
-class UIForgeFeatureToggles {
+class Forge SpaceFeatureToggles {
   constructor(config = {}) {
     this.client = new UnleashClient({
-      appName: 'uiforge-app',
+      appName: 'forgespace-app',
       url: config.unleashUrl || 'http://localhost:4242/api',
-      clientKey: config.clientKey || 'uiforge-token',
+      clientKey: config.clientKey || 'forgespace-token',
       refreshInterval: 60000, // 1 minute
       metricsInterval: 60000,  // 1 minute
     });
@@ -181,7 +181,7 @@ class UIForgeFeatureToggles {
   }
 }
 
-module.exports = UIForgeFeatureToggles;
+module.exports = Forge SpaceFeatureToggles;
 ```
 
 ### Python Integration
@@ -191,13 +191,13 @@ module.exports = UIForgeFeatureToggles;
 from unleash_client import UnleashClient
 from typing import Dict, Any, Optional
 
-class UIForgeFeatureToggles:
+class Forge SpaceFeatureToggles:
     def __init__(self, config: Dict[str, Any] = None):
         self.config = config or {}
         self.client = UnleashClient(
             url=self.config.get('unleash_url', 'http://localhost:4242/api'),
-            app_name='uiforge-app',
-            client_key=self.config.get('client_key', 'uiforge-token'),
+            app_name='forgespace-app',
+            client_key=self.config.get('client_key', 'forgespace-token'),
             refresh_interval=60,  # 1 minute
             metrics_interval=60,  # 1 minute
         )
@@ -282,7 +282,7 @@ interface FeatureToggleProviderProps {
 export const FeatureToggleProvider: React.FC<FeatureToggleProviderProps> = ({
   children,
   unleashUrl = 'http://localhost:4242/api',
-  clientKey = 'uiforge-token',
+  clientKey = 'forgespace-token',
   userId
 }) => {
   const [client, setClient] = useState<UnleashClient | null>(null);
@@ -290,7 +290,7 @@ export const FeatureToggleProvider: React.FC<FeatureToggleProviderProps> = ({
 
   useEffect(() => {
     const unleashClient = new UnleashClient({
-      appName: 'uiforge-webapp',
+      appName: 'siza',
       url: unleashUrl,
       clientKey,
       refreshInterval: 60000,
@@ -485,7 +485,7 @@ unleash:
   authentication:
     type: 'unsecure'  # For local development
     createAdminUser: true
-    adminEmail: 'admin@uiforge.local'
+    adminEmail: 'admin@forgespace.local'
 
   database:
     type: 'postgres'

--- a/patterns/ide-extensions/README.md
+++ b/patterns/ide-extensions/README.md
@@ -17,6 +17,6 @@ Alpha stub with command palette integration. See [`vscode/README.md`](./vscode/R
 
 ## MCP-First Strategy
 
-For AI-assisted IDEs (Windsurf, Cursor, Claude Desktop), the [UIForge Context MCP Server](../../src/mcp-context-server/) provides the primary integration path — giving AI agents direct access to project context and forge-patterns documentation without requiring a native extension.
+For AI-assisted IDEs (Windsurf, Cursor, Claude Desktop), the [Forge Space Context MCP Server](../../src/mcp-context-server/) provides the primary integration path — giving AI agents direct access to project context and forge-patterns documentation without requiring a native extension.
 
 Native extensions complement this by providing GUI-driven pattern application for developers who prefer not to use AI agents.

--- a/patterns/ide-extensions/vscode/README.md
+++ b/patterns/ide-extensions/vscode/README.md
@@ -51,4 +51,4 @@ npx vsce package  # Build .vsix for distribution
 
 ## MCP Integration
 
-This extension is designed to work alongside the UIForge Context MCP Server. Set `forgePatterns.mcpServerUrl` when that integration is available.
+This extension is designed to work alongside the Forge Space Context MCP Server. Set `forgePatterns.mcpServerUrl` when that integration is available.

--- a/patterns/localstack/README.md
+++ b/patterns/localstack/README.md
@@ -29,7 +29,7 @@ aws --endpoint-url=http://localhost:4566 s3 mb s3://my-test-bucket
 
 ## Network
 
-Runs on `uiforge-local-network`. Other containers connect via hostname `localstack:4566`.
+Runs on `forgespace-local-network`. Other containers connect via hostname `localstack:4566`.
 
 ## Security
 

--- a/patterns/mcp-servers/streaming/README.md
+++ b/patterns/mcp-servers/streaming/README.md
@@ -31,11 +31,11 @@ This directory contains streaming patterns designed for real-time communication 
 ### Server-Sent Events Example
 
 ```javascript
-const UIForgeFeatureToggles = require('@uiforge/feature-toggles');
+const Forge SpaceFeatureToggles = require('@forgespace/feature-toggles');
 
-const features = new UIForgeFeatureToggles({
-  appName: 'uiforge-mcp',
-  projectNamespace: 'uiforge-mcp'
+const features = new Forge SpaceFeatureToggles({
+  appName: 'ui-mcp',
+  projectNamespace: 'ui-mcp'
 });
 
 // SSE streaming middleware
@@ -132,13 +132,13 @@ patterns/mcp-servers/streaming/
 
 ```bash
 # Enable SSE streaming
-forge-features enable uiforge-mcp.sse-streaming
+forge-features enable ui-mcp.sse-streaming
 
 # Enable WebSocket streaming
-forge-features enable uiforge-mcp.websocket-streaming
+forge-features enable ui-mcp.websocket-streaming
 
 # Enable real-time analytics
-forge-features enable uiforge-mcp.real-time-analytics
+forge-features enable ui-mcp.real-time-analytics
 
 # Enable stream compression
 forge-features enable global.stream-compression

--- a/patterns/monitoring/SHARED_LOGGING_IMPLEMENTATION.md
+++ b/patterns/monitoring/SHARED_LOGGING_IMPLEMENTATION.md
@@ -1,6 +1,6 @@
-# Shared Logging Implementation for UIForge Ecosystem
+# Shared Logging Implementation for Forge Space Ecosystem
 
-This document provides comprehensive guidance for implementing shared logging across the UIForge ecosystem with Sentry integration and service identification.
+This document provides comprehensive guidance for implementing shared logging across the Forge Space ecosystem with Sentry integration and service identification.
 
 ## Overview
 
@@ -15,7 +15,7 @@ The shared logging system provides:
 
 ```
 ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
-│   mcp-gateway     │    │   uiforge-mcp     │    │   uiforge-webapp   │
+│   mcp-gateway     │    │   ui-mcp     │    │   siza   │
 │   (Python)         │    │   (Node.js)       │    │   (Next.js)       │
 └─────────┬────────┘    └─────────┬────────┘    └─────────┬────────┘
          │                        │                        │
@@ -87,7 +87,7 @@ init_sentry(
 await monitor_mcp_tool_execution('tool_name', success=True, duration=1500)
 ```
 
-### uiforge-mcp (Node.js)
+### ui-mcp (Node.js)
 
 #### Files Created:
 - `src/lib/sentry-shared.ts` - Enhanced Sentry integration with shared logging
@@ -109,7 +109,7 @@ import { getSharedLogger } from './lib/shared-logger';
 initSentry({
   dsn: process.env.SENTRY_DSN,
   environment: process.env.NODE_ENV,
-  serviceName: 'uiforge-mcp',
+  serviceName: 'ui-mcp',
   enableSupabase: true,
   supabaseUrl: process.env.SUPABASE_URL,
   supabaseKey: process.env.SUPABASE_KEY
@@ -119,7 +119,7 @@ initSentry({
 await monitorMcpToolExecution('tool_name', success=True, duration=1500);
 ```
 
-### uiforge-webapp (Next.js)
+### siza (Next.js)
 
 #### Files Created:
 - `apps/web/src/lib/sentry-shared.ts` - Enhanced Sentry integration with shared logging
@@ -142,7 +142,7 @@ import { getSharedLoggerClient } from './lib/shared-logger';
 initClientSentry({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   environment: process.env.NODE_ENV,
-  serviceName: 'uiforge-webapp',
+  serviceName: 'siza',
   enableSupababase: true,
   supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL,
   supabaseKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
@@ -195,7 +195,7 @@ async def handle_request(request):
 ```
 
 ```typescript
-// Node.js (uiforge-mcp)
+// Node.js (ui-mcp)
 import { createCorrelationContext } from './lib/sentry-shared';
 
 const { correlationId, cleanup } = createCorrelationId();
@@ -207,7 +207,7 @@ try {
 ```
 
 ```typescript
-// Next.js (uiforge-webapp)
+// Next.js (siza)
 import { createCorrelationContext } from './lib/sentry-shared';
 
 const { correlationId, cleanup } = createCorrelationContext();
@@ -274,7 +274,7 @@ The monitoring dashboard provides:
 - **Sentry Integration**: Direct links to Sentry traces
 
 ### Access:
-- Navigate to `/monitoring` in the uiforge-webapp
+- Navigate to `/monitoring` in the siza
 - View real-time logs from all three services
 - Filter and search for specific events
 - Export data for analysis

--- a/patterns/monitoring/sentry-supabase.md
+++ b/patterns/monitoring/sentry-supabase.md
@@ -1,7 +1,7 @@
 # Sentry Supabase Monitoring Pattern
 
 ## Overview
-Sentry error tracking and performance monitoring with Supabase integration for the UIForge ecosystem.
+Sentry error tracking and performance monitoring with Supabase integration for the Forge Space ecosystem.
 
 ## Category
 Monitoring
@@ -11,8 +11,8 @@ sentry, supabase, monitoring, error-tracking, performance
 
 ## Framework Support
 - Python (mcp-gateway)
-- Node.js (uiforge-mcp)
-- Next.js (uiforge-webapp)
+- Node.js (ui-mcp)
+- Next.js (siza)
 
 ## Dependencies
 
@@ -67,12 +67,12 @@ Set up environment variables for each project in `.env.local`
 pip install sentry-sdk[fastapi] structlog psycopg2-binary
 ```
 
-#### Node.js (uiforge-mcp)
+#### Node.js (ui-mcp)
 ```bash
 npm install @sentry/node @sentry/tracing @supabase/sentry-js-integration
 ```
 
-#### Next.js (uiforge-webapp)
+#### Next.js (siza)
 ```bash
 npm install @sentry/nextjs @supabase/sentry-js-integration
 ```
@@ -223,4 +223,4 @@ Track AI model usage and performance
 ## Support Resources
 - Sentry Documentation: https://docs.sentry.io/
 - Supabase Integration Guide: https://supabase.com/docs/guides/platform/sentry
-- UIForge Documentation
+- Forge Space Documentation

--- a/patterns/security/authentication/README.md
+++ b/patterns/security/authentication/README.md
@@ -1,8 +1,8 @@
-# Authentication Patterns for UIForge Projects
+# Authentication Patterns for Forge Space Projects
 
 ## 🎯 Overview
 
-This directory contains authentication patterns designed for secure, zero-secrets development across the UIForge ecosystem. All patterns support centralized feature toggle integration and follow security best practices.
+This directory contains authentication patterns designed for secure, zero-secrets development across the Forge Space ecosystem. All patterns support centralized feature toggle integration and follow security best practices.
 
 ## 📋 Available Patterns
 
@@ -31,10 +31,10 @@ This directory contains authentication patterns designed for secure, zero-secret
 ### JWT Authentication Example
 
 ```javascript
-const UIForgeFeatureToggles = require('@uiforge/feature-toggles');
+const Forge SpaceFeatureToggles = require('@forgespace/feature-toggles');
 
 // Initialize feature toggles
-const features = new UIForgeFeatureToggles({
+const features = new Forge SpaceFeatureToggles({
   appName: 'mcp-gateway',
   projectNamespace: 'mcp-gateway'
 });
@@ -110,13 +110,13 @@ patterns/security/authentication/
 forge-features enable mcp-gateway.jwt-auth
 
 # Enable OAuth authentication
-forge-features enable uiforge-webapp.oauth-auth
+forge-features enable siza.oauth-auth
 
 # Enable API key authentication
 forge-features enable mcp-gateway.api-key-auth
 
 # Enable multi-factor authentication
-forge-features enable uiforge-webapp.multi-factor-auth
+forge-features enable siza.multi-factor-auth
 ```
 
 ## 🔒 Security Considerations

--- a/patterns/security/middleware/README.md
+++ b/patterns/security/middleware/README.md
@@ -1,8 +1,8 @@
-# Security Middleware Patterns for UIForge Projects
+# Security Middleware Patterns for Forge Space Projects
 
 ## 🎯 Overview
 
-This directory contains security middleware patterns designed to provide comprehensive protection for UIForge applications. All middleware integrates with the centralized feature toggle system and follows zero-secrets principles.
+This directory contains security middleware patterns designed to provide comprehensive protection for Forge Space applications. All middleware integrates with the centralized feature toggle system and follows zero-secrets principles.
 
 ## 📋 Available Patterns
 
@@ -36,10 +36,10 @@ This directory contains security middleware patterns designed to provide compreh
 ### Rate Limiting Example
 
 ```javascript
-const UIForgeFeatureToggles = require('@uiforge/feature-toggles');
+const Forge SpaceFeatureToggles = require('@forgespace/feature-toggles');
 
 // Initialize feature toggles
-const features = new UIForgeFeatureToggles({
+const features = new Forge SpaceFeatureToggles({
   appName: 'mcp-gateway',
   projectNamespace: 'mcp-gateway'
 });
@@ -138,7 +138,7 @@ forge-features enable mcp-gateway.rate-limiting
 forge-features enable mcp-gateway.security-headers
 
 # Enable CORS protection
-forge-features enable uiforge-webapp.cors-protection
+forge-features enable siza.cors-protection
 
 # Enable input validation
 forge-features enable mcp-gateway.input-validation
@@ -254,7 +254,7 @@ app.prepare().then(() => {
 ### Environment Variables
 ```bash
 # CORS Configuration
-CORS_ORIGINS=http://localhost:3000,https://uiforge.com
+CORS_ORIGINS=http://localhost:3000,https://forgespace.co
 CORS_METHODS=GET,POST,PUT,DELETE
 CORS_CREDENTIALS=true
 

--- a/patterns/shared-constants/README.md
+++ b/patterns/shared-constants/README.md
@@ -3,7 +3,7 @@
 Centralised constants, types, and factory helpers extracted from all Forge ecosystem projects.
 
 **Version:** 1.0.0
-**Sources:** `mcp-gateway`, `uiforge-mcp`, `UIForge`
+**Sources:** `mcp-gateway`, `ui-mcp`, `Forge Space`
 
 ---
 
@@ -34,7 +34,7 @@ import {
   AI_PROVIDERS,
   createFeatureFlags,
   createStorageConfig,
-} from '@uiforge/forge-patterns/shared-constants';
+} from '@forgespace/forge-patterns/shared-constants';
 ```
 
 ---

--- a/patterns/shared-infrastructure/docker-optimization/README.md
+++ b/patterns/shared-infrastructure/docker-optimization/README.md
@@ -1,4 +1,4 @@
-# Docker Optimization Patterns for UIForge Projects
+# Docker Optimization Patterns for Forge Space Projects
 
 ## 🎯 Overview
 
@@ -116,10 +116,10 @@ forge-features enable global.docker-optimization
 forge-features enable mcp-gateway.multi-stage-builds
 
 # Enable resource monitoring
-forge-features enable uiforge-mcp.resource-monitoring
+forge-features enable ui-mcp.resource-monitoring
 
 # Enable auto-scaling
-forge-features enable uiforge-webapp.auto-scaling
+forge-features enable siza.auto-scaling
 ```
 
 ## 🚀 Performance Metrics
@@ -133,9 +133,9 @@ forge-features enable uiforge-webapp.auto-scaling
 
 ### Optimization Techniques
 ```javascript
-const UIForgeFeatureToggles = require('@uiforge/feature-toggles');
+const Forge SpaceFeatureToggles = require('@forgespace/feature-toggles');
 
-const features = new UIForgeFeatureToggles({
+const features = new Forge SpaceFeatureToggles({
   appName: 'docker-optimizer',
   projectNamespace: 'shared-infrastructure'
 });
@@ -269,20 +269,20 @@ services:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: uiforge-app
+  name: forgespace-app
 spec:
   replicas: 2
   selector:
     matchLabels:
-      app: uiforge-app
+      app: forgespace-app
   template:
     metadata:
       labels:
-        app: uiforge-app
+        app: forgespace-app
     spec:
       containers:
       - name: app
-        image: uiforge/app:optimized
+        image: forgespace/app:optimized
         resources:
           requests:
             memory: "256Mi"


### PR DESCRIPTION
## Summary

Completes the UIForge → Forge Space rebrand in pattern README files.
All brand references updated; backwards-compat code constants (e.g. `MCP_UIFORGE_SERVER_NAME`) intentionally preserved.

## Files Changed (14)

| File | Changes |
|------|---------|
| patterns/config/README.md | UIForge → Forge Space, uiforge-mcp → ui-mcp |
| patterns/coverage/coverage-standards.md | UIForge → Forge Space, uiforge-mcp → ui-mcp |
| patterns/docker/README.md | UIForge → Forge Space |
| patterns/feature-toggles/README.md | UIForge → Forge Space, uiforge-mcp → ui-mcp, token/app names |
| patterns/ide-extensions/README.md | UIForge → Forge Space |
| patterns/ide-extensions/vscode/README.md | UIForge → Forge Space |
| patterns/localstack/README.md | uiforge-local-network → forgespace-local-network |
| patterns/mcp-servers/streaming/README.md | UIForge → Forge Space, uiforge-mcp → ui-mcp |
| patterns/monitoring/sentry-supabase.md | uiforge-mcp → ui-mcp |
| patterns/monitoring/SHARED_LOGGING_IMPLEMENTATION.md | uiforge-mcp → ui-mcp |
| patterns/security/authentication/README.md | UIForge → Forge Space |
| patterns/security/middleware/README.md | UIForge → Forge Space, domain |
| patterns/shared-constants/README.md | uiforge-mcp → ui-mcp (retained deprecated constant) |
| patterns/shared-infrastructure/docker-optimization/README.md | uiforge-* → forgespace-* |

## Substitutions Applied

- `UIForge Patterns` → `Forge Space Core`
- `UIForge MCP` → `Forge UI MCP`
- `UIForge` → `Forge Space`
- `uiforge-mcp` → `ui-mcp`
- `uiforge-webapp` → `siza`
- `uiforge.com` → `forgespace.co`
- `uiforge.local` → `forgespace.local`
- `uiforge-token` → `forgespace-token`
- `uiforge-app` → `forgespace-app`

652 tests pass. No source code changed.