### PR TITLE
docs(specs): bootstrap spec and roadmap flow

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,7 +8,7 @@ _(none)_
 
 ## Next (proposed)
 
-- **2026-04-15-ecosystem-roadmap-specs**  _(proposed)_  `roadmap,specs,ecosystem`
+- **2026-04-15-ecosystem-roadmap-specs** _(proposed)_ `roadmap,specs,ecosystem`
 
 ## Recently shipped
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,15 @@
+# Roadmap - core
+
+_Auto-regenerated 2026-04-15 from `docs/specs/`._
+
+## Now (active)
+
+_(none)_
+
+## Next (proposed)
+
+- **2026-04-15-ecosystem-roadmap-specs**  _(proposed)_  `roadmap,specs,ecosystem`
+
+## Recently shipped
+
+_(none)_

--- a/docs/specs/2026-04-15-ecosystem-roadmap-specs/spec.md
+++ b/docs/specs/2026-04-15-ecosystem-roadmap-specs/spec.md
@@ -9,13 +9,23 @@ tags: roadmap,specs,ecosystem
 # ecosystem-roadmap-specs
 
 ## Goal
-Establish committed feature specs and a generated roadmap for the Forge Space core product surface.
+
+Establish committed feature specs and a generated roadmap for the Forge Space
+core product surface.
 
 ## Context
-Core is the cross-repo coordination point for ecosystem plans and prompts. Keeping specs in-repo makes RAG retrieval precise without loading the whole docs tree.
+
+Core is the cross-repo coordination point for ecosystem plans and prompts.
+Keeping specs in-repo makes RAG retrieval precise without loading the whole docs
+tree.
 
 ## Approach
-Seed the spec lifecycle with one proposed roadmap/spec adoption item, keep the generated roadmap derived from frontmatter, and let future feature work add focused specs.
+
+Seed the spec lifecycle with one proposed roadmap/spec adoption item, keep the
+generated roadmap derived from frontmatter, and let future feature work add
+focused specs.
 
 ## Verification
-docs/roadmap.md lists this proposed spec and the spec files are picked up by the shared RAG spec/roadmap source types.
+
+docs/roadmap.md lists this proposed spec and the spec files are picked up by the
+shared RAG spec/roadmap source types.

--- a/docs/specs/2026-04-15-ecosystem-roadmap-specs/spec.md
+++ b/docs/specs/2026-04-15-ecosystem-roadmap-specs/spec.md
@@ -1,0 +1,21 @@
+---
+status: proposed
+created: 2026-04-15
+owner: lucassantana
+pr:
+tags: roadmap,specs,ecosystem
+---
+
+# ecosystem-roadmap-specs
+
+## Goal
+Establish committed feature specs and a generated roadmap for the Forge Space core product surface.
+
+## Context
+Core is the cross-repo coordination point for ecosystem plans and prompts. Keeping specs in-repo makes RAG retrieval precise without loading the whole docs tree.
+
+## Approach
+Seed the spec lifecycle with one proposed roadmap/spec adoption item, keep the generated roadmap derived from frontmatter, and let future feature work add focused specs.
+
+## Verification
+docs/roadmap.md lists this proposed spec and the spec files are picked up by the shared RAG spec/roadmap source types.

--- a/docs/specs/2026-04-15-ecosystem-roadmap-specs/tasks.md
+++ b/docs/specs/2026-04-15-ecosystem-roadmap-specs/tasks.md
@@ -1,0 +1,7 @@
+# Tasks - ecosystem-roadmap-specs
+
+- [ ] Review current roadmap/backlog signals for the repo
+- [ ] Convert the next non-trivial feature into a focused spec
+- [ ] Keep docs/roadmap.md generated from specs, not hand-edited
+- [ ] Verify RAG returns this spec via source_type=spec or roadmap
+- [ ] Link the implementation PR before marking shipped


### PR DESCRIPTION
## Summary
- seed Agent-OS-style feature spec placeholder
- generate docs/roadmap.md from spec frontmatter
- make the repo visible to the shared RAG spec/roadmap workflow

## Verification
- docs-only change; inspected generated roadmap and spec layout


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new roadmap documentation page organizing features into active, proposed, and recently shipped categories.
  * Established ecosystem roadmap specifications framework with structured spec documents, task checklists, and knowledge retrieval integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->